### PR TITLE
Fix syntax highlighting on windows

### DIFF
--- a/python/nammu/view/AtfAreaView.py
+++ b/python/nammu/view/AtfAreaView.py
@@ -137,7 +137,8 @@ class AtfAreaView(JPanel):
         Implements syntax highlighting based on pyoracc.
         """
         lexer = AtfLexer(skipinvalid=True).lexer
-        text = self.editArea.text
+        text = self.edit_area_styledoc.getText(0,
+                 self.edit_area_styledoc.getLength())
         splittext = text.split('\n')
         lexer.input(text)
         # Reset all styling


### PR DESCRIPTION
The text in the edit pane and and the styled document may be slightly… different

It seems like the styled document normalizes the windows line endings away so make sure that we use the same text for lexing that we are syntax highlighting