### PR TITLE
Persistent syntax highlight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ parsetab.py
 .tags
 **/.cache
 **/effective-pom*.xml
+*.atf

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>uk.ac.ucl.rc.development.oracc</groupId>
 	<artifactId>nammu</artifactId>
-	<version>0.1.1</version>
+	<version>0.2-dev</version>
 	<packaging>jar</packaging>
 
 	<name>nammu</name>

--- a/python/nammu/controller/AtfAreaController.py
+++ b/python/nammu/controller/AtfAreaController.py
@@ -59,7 +59,6 @@ class AtfAreaController(object):
         '''
         with self.view.edit_listener.force_compound():
             self.view.edit_area.setText(text)
-            self.syntax_highlight()
         self.update_line_numbers()
 
     def getAtfAreaText(self):

--- a/python/nammu/controller/AtfAreaController.py
+++ b/python/nammu/controller/AtfAreaController.py
@@ -47,7 +47,6 @@ class AtfAreaController(object):
         self.line_numbers_styledoc = self.line_numbers_area.getStyledDocument()
         # Syntax highlighting
         self.syntax_highlighter = SyntaxHighlighter(self)
-#       self.syntax_highlighter = SyntaxHighlighter(self.line_numbers_styledoc)
 
     def setAtfAreaText(self, text):
         '''
@@ -59,7 +58,6 @@ class AtfAreaController(object):
         '''
         with self.view.edit_listener.force_compound():
             self.view.edit_area.setText(text)
-        self.update_line_numbers()
 
     def getAtfAreaText(self):
         '''
@@ -153,4 +151,7 @@ class AtfAreaController(object):
         self.line_numbers_area.setText(numbers)
 
     def syntax_highlight(self):
+        '''
+        Short hand for syntax highlighting.
+        '''
         self.syntax_highlighter.syntax_highlight()

--- a/python/nammu/controller/AtfAreaController.py
+++ b/python/nammu/controller/AtfAreaController.py
@@ -118,11 +118,10 @@ class AtfAreaController(object):
             pass
         else:
             self.update_line_numbers()
-        
+
     def __getattr__(self, name):
         '''
-        Calls to copy, paste and cut methods are just passed to text area. 
+        Calls to copy, paste and cut methods are just passed to text area.
         '''
         if name in ('copy', 'paste', 'cut'):
             return getattr(self.view.editArea, name)
-            

--- a/python/nammu/controller/AtfAreaController.py
+++ b/python/nammu/controller/AtfAreaController.py
@@ -47,9 +47,17 @@ class AtfAreaController(object):
         self.update_line_numbers()
 
     def getAtfAreaText(self):
+        '''
+        Short hand for getting Nammu's text area's content.
+        '''
         return self.view.editArea.getText()
 
     def clearAtfArea(self):
+        '''
+        Every time we clear the ATF text area we also need to clear the edits
+        pile, repaint the line numbers and remove the styling from previous
+        validation highlight.
+        '''
         self.view.editArea.setText("")
         # When opening a new file we should discard the previous edits
         self.view.undo_manager.discardAllEdits()
@@ -75,17 +83,22 @@ class AtfAreaController(object):
         self.view.editArea.setToolTipText(None)
 
     def update_line_numbers(self):
+        '''
+        Update line numbers area when text length changes.
+        '''
         # Get how many lines are in the file
         n_lines = self.getAtfAreaText().count('\n')
         # Reload line numbers text panel
         self.view.repaint_line_numbers(n_lines)
 
     def undo(self):
-        # CompoundEdits only get added  to the undo manager when the next
-        # INSERT/REMOVE event happens. Thus, if we are adding changes to
-        # the current compound edit and we want to undo it before the next
-        # INSERT/REMOVE happens, we won't be able until it's been explicitly
-        # ended.
+        '''
+        CompoundEdits only get added  to the undo manager when the next
+        INSERT/REMOVE event happens. Thus, if we are adding changes to
+        the current compound edit and we want to undo it before the next
+        INSERT/REMOVE happens, we won't be able until it's been explicitly
+        ended.
+        '''
         self.view.edit_listener.current_compound.end()
         try:
             self.undo_manager.undo()
@@ -105,15 +118,11 @@ class AtfAreaController(object):
             pass
         else:
             self.update_line_numbers()
-
-    def copy(self):
-        self.view.editArea.copy()
-        self.update_line_numbers()
-
-    def paste(self):
-        self.view.editArea.paste()
-        self.update_line_numbers()
-
-    def cut(self):
-        self.view.editArea.cut()
-        self.update_line_numbers()
+        
+    def __getattr__(self, name):
+        '''
+        Calls to copy, paste and cut methods are just passed to text area. 
+        '''
+        if name in ('copy', 'paste', 'cut'):
+            return getattr(self.view.editArea, name)
+            

--- a/python/nammu/controller/AtfAreaController.py
+++ b/python/nammu/controller/AtfAreaController.py
@@ -57,6 +57,15 @@ class AtfAreaController(object):
         self.view.repaint_line_numbers(0)
         # Clear tooltips
         self.clearToolTips()
+        # Clear validation errors
+        self.clear_validation_errors()
+        
+    def clear_validation_errors(self):
+        '''
+        Clear validation errors not to inherit wrong styling from previously
+        open files.
+        '''
+        self.view.validation_errors = {}
 
     def clearToolTips(self):
         '''

--- a/python/nammu/controller/AtfAreaController.py
+++ b/python/nammu/controller/AtfAreaController.py
@@ -18,7 +18,11 @@ along with Nammu.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
 from javax.swing.undo import CannotUndoException, CannotRedoException
+
 from ..view.AtfAreaView import AtfAreaView
+from ..view.LineNumbersArea import LineNumbersArea
+from ..view.AtfEditArea import AtfEditArea
+from ..view.SyntaxHighlighter import SyntaxHighlighter
 
 
 class AtfAreaController(object):
@@ -26,12 +30,24 @@ class AtfAreaController(object):
     Creates the ATF area (edit/object) view and handles its actions.
     '''
     def __init__(self, mainControler):
+        # Create text edition area
+        self.edit_area = AtfEditArea(self)
+        # Create text panel to display the line numbers
+        self.line_numbers_area = LineNumbersArea()
         # Create view with a reference to its controller to handle events
         self.view = AtfAreaView(self)
         # Will also need delegating to parent presenter
         self.controller = mainControler
         # Get a reference to the view's undo_manager
         self.undo_manager = self.view.undo_manager
+        # Initialise validation errors
+        self.validation_errors = {}
+        # Needed by syntax highlighter
+        self.edit_area_styledoc = self.edit_area.getStyledDocument()
+        self.line_numbers_styledoc = self.line_numbers_area.getStyledDocument()
+        # Syntax highlighting
+        self.syntax_highlighter = SyntaxHighlighter(self)
+#       self.syntax_highlighter = SyntaxHighlighter(self.line_numbers_styledoc)
 
     def setAtfAreaText(self, text):
         '''
@@ -42,15 +58,15 @@ class AtfAreaController(object):
         INSERT event, so we have to manually group those two together.
         '''
         with self.view.edit_listener.force_compound():
-            self.view.editArea.setText(text)
-            self.view.syntax_highlight()
+            self.view.edit_area.setText(text)
+            self.syntax_highlight()
         self.update_line_numbers()
 
     def getAtfAreaText(self):
         '''
         Short hand for getting Nammu's text area's content.
         '''
-        return self.view.editArea.getText()
+        return self.view.edit_area.getText()
 
     def clearAtfArea(self):
         '''
@@ -58,29 +74,22 @@ class AtfAreaController(object):
         pile, repaint the line numbers and remove the styling from previous
         validation highlight.
         '''
-        self.view.editArea.setText("")
+        self.view.edit_area.setText("")
         # When opening a new file we should discard the previous edits
         self.view.undo_manager.discardAllEdits()
         # Reload line numbers text panel
-        self.view.repaint_line_numbers(0)
+        self.repaint_line_numbers(0)
         # Clear tooltips
         self.clearToolTips()
         # Clear validation errors
-        self.clear_validation_errors()
-
-    def clear_validation_errors(self):
-        '''
-        Clear validation errors not to inherit wrong styling from previously
-        open files.
-        '''
-        self.view.validation_errors = {}
+        self.validation_errors = {}
 
     def clearToolTips(self):
         '''
         We don't want tooltips from previous validations appearing after the
         file has been re-validated or another file has been opened.
         '''
-        self.view.editArea.setToolTipText(None)
+        self.view.edit_area.setToolTipText(None)
 
     def update_line_numbers(self):
         '''
@@ -89,7 +98,13 @@ class AtfAreaController(object):
         # Get how many lines are in the file
         n_lines = self.getAtfAreaText().count('\n')
         # Reload line numbers text panel
-        self.view.repaint_line_numbers(n_lines)
+        self.repaint_line_numbers(n_lines)
+
+    def set_validation_errors(self, validation_errors):
+        '''
+        Short hand for refreshing validation errors in ATF area.
+        '''
+        self.validation_errors = validation_errors
 
     def undo(self):
         '''
@@ -124,4 +139,19 @@ class AtfAreaController(object):
         Calls to copy, paste and cut methods are just passed to text area.
         '''
         if name in ('copy', 'paste', 'cut'):
-            return getattr(self.view.editArea, name)
+            return getattr(self.view.edit_area, name)
+
+    def repaint_line_numbers(self, n_lines):
+        '''
+        Draws line numbers in corresponding panel.
+        '''
+        # Create line numbers
+        numbers = ""
+        for line in range(n_lines + 1):
+            numbers += str(line + 1) + ": \n"
+
+        # Print in line numbers' area
+        self.line_numbers_area.setText(numbers)
+
+    def syntax_highlight(self):
+        self.syntax_highlighter.syntax_highlight()

--- a/python/nammu/controller/AtfAreaController.py
+++ b/python/nammu/controller/AtfAreaController.py
@@ -59,7 +59,7 @@ class AtfAreaController(object):
         self.clearToolTips()
         # Clear validation errors
         self.clear_validation_errors()
-        
+
     def clear_validation_errors(self):
         '''
         Clear validation errors not to inherit wrong styling from previously

--- a/python/nammu/controller/ConsoleController.py
+++ b/python/nammu/controller/ConsoleController.py
@@ -31,5 +31,5 @@ class ConsoleController(object):
         self.controller = mainControler
 
     def addText(self, text):
-        self.view.editArea.append(text)
+        self.view.edit_area.append(text)
         self.view.scroll()

--- a/python/nammu/controller/NammuController.py
+++ b/python/nammu/controller/NammuController.py
@@ -296,9 +296,6 @@ class NammuController(object):
         # Clear tooltips from last validation
         self.atfAreaController.clearToolTips()
 
-        # Clear colouring in line number from previous validation
-        self.atfAreaController.update_line_numbers()
-
         if self.currentFilename:
             self.logger.debug("Validating ATF file %s.", self.currentFilename)
 
@@ -334,9 +331,6 @@ class NammuController(object):
 
         # Clear tooltips from last validation
         self.atfAreaController.clearToolTips()
-
-        # Clear colouring in line number from previous validation
-        self.atfAreaController.update_line_numbers()
 
         if self.currentFilename:
             self.logger.debug("Lemmatising ATF file %s.", self.currentFilename)
@@ -438,8 +432,10 @@ class NammuController(object):
         # Check if there were any validation errors and pass them to the
         # ATF area to refresh syntax highlighting.
         self.process_validation_errors(oracc_log)
+        # Always syntax highlight, not only when there are errors, otherwise
+        # old error lines' styling won't be cleared!
+        self.atfAreaController.syntax_highlight()
         if oracc_log:
-            self.atfAreaController.syntax_highlight()
             # TODO: Prompt dialog.
             if autolem:
                 self.logger.info("The lemmatisation returned some "

--- a/python/nammu/controller/NammuController.py
+++ b/python/nammu/controller/NammuController.py
@@ -439,9 +439,10 @@ class NammuController(object):
         If we are lemmatising, it'll also return:
           * <filename>_autolem.atf: lemmatised version of file
         """
+        validation_errors = self.get_validation_errors(oracc_log)
+        self.atfAreaController.view.validation_errors = validation_errors
         if oracc_log:
-            validation_errors = self.get_validation_errors(oracc_log)
-            self.atfAreaController.view.error_highlight(validation_errors)
+            self.atfAreaController.view.syntax_highlight()
             # TODO: Prompt dialog.
             if autolem:
                 self.logger.info("The lemmatisation returned some "

--- a/python/nammu/controller/NammuController.py
+++ b/python/nammu/controller/NammuController.py
@@ -18,30 +18,28 @@ along with Nammu.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
 import codecs
-import os
+from logging import StreamHandler, Formatter
 import logging
 import logging.config
-import urllib
-
-from logging import StreamHandler, Formatter
 from logging.handlers import RotatingFileHandler
-from requests.exceptions import RequestException
-from requests.exceptions import Timeout, ConnectionError, HTTPError
-
-from java.awt import Desktop
-from java.net import URI
-from java.io import File
-from java.lang import System, Integer, ClassLoader
-from javax.swing import JFileChooser, JOptionPane, ToolTipManager
-from javax.swing.filechooser import FileNameExtensionFilter
+import os
+import urllib
 
 from AtfAreaController import AtfAreaController
 from ConsoleController import ConsoleController
 from MenuController import MenuController
 from ModelController import ModelController
 from ToolbarController import ToolbarController
-
+from java.awt import Desktop
+from java.io import File
+from java.lang import System, Integer, ClassLoader
+from java.net import URI
+from javax.swing import JFileChooser, JOptionPane, ToolTipManager
+from javax.swing.filechooser import FileNameExtensionFilter
 from pyoracc.atf.atffile import AtfFile
+from requests.exceptions import RequestException
+from requests.exceptions import Timeout, ConnectionError, HTTPError
+
 from ..SOAPClient.SOAPClient import SOAPClient
 from ..utils import get_yaml_config
 from ..utils.NammuConsoleHandler import NammuConsoleHandler
@@ -113,7 +111,6 @@ class NammuController(object):
         2. Clear text area
         3. See GitHub issue: https://github.com/UCL-RITS/nammu/issues/6
         '''
-
         if self.handleUnsaved():
             self.atfAreaController.clearAtfArea()
             self.view.setTitle("Nammu")
@@ -129,7 +126,6 @@ class NammuController(object):
         3. Load file in text area
         4. Display file name in title bar
         '''
-
         if self.handleUnsaved():
             if self.currentFilename:
                 default_path = os.path.dirname(self.currentFilename)
@@ -295,7 +291,7 @@ class NammuController(object):
         However, the intention is to replace this with validation by pyoracc.
         '''
         # Clear previous log in Nammu's console
-        self.consoleController.view.editArea.setText("")
+        self.consoleController.view.edit_area.setText("")
 
         # Clear tooltips from last validation
         self.atfAreaController.clearToolTips()
@@ -334,7 +330,7 @@ class NammuController(object):
         Don't lemmatise if file doesn't validate.
         '''
         # Clear previous log in Nammu's console
-        self.consoleController.view.editArea.setText("")
+        self.consoleController.view.edit_area.setText("")
 
         # Clear tooltips from last validation
         self.atfAreaController.clearToolTips()
@@ -439,10 +435,11 @@ class NammuController(object):
         If we are lemmatising, it'll also return:
           * <filename>_autolem.atf: lemmatised version of file
         """
-        validation_errors = self.get_validation_errors(oracc_log)
-        self.atfAreaController.view.validation_errors = validation_errors
+        # Check if there were any validation errors and pass them to the
+        # ATF area to refresh syntax highlighting.
+        self.process_validation_errors(oracc_log)
         if oracc_log:
-            self.atfAreaController.view.syntax_highlight()
+            self.atfAreaController.syntax_highlight()
             # TODO: Prompt dialog.
             if autolem:
                 self.logger.info("The lemmatisation returned some "
@@ -508,13 +505,12 @@ class NammuController(object):
                 self.logger.error("Unexpected error when waiting for ORACC "
                                   "server to prepare response.")
 
-    def get_validation_errors(self, oracc_log):
+    def process_validation_errors(self, oracc_log):
         """
-        Reads the log from the oracc server from the validation, and returns a
-        dictionary with line numbers and error messages.
+        Reads the log from the oracc server from the validation, and refreshes
+        the dictionary with line numbers and error messages.
         """
-        validation_errors = {}
-
+        validation_errors_server = {}
         for line in oracc_log.splitlines():
             if ':' in line:
                 line_number = line.split(':')[1]
@@ -523,19 +519,20 @@ class NammuController(object):
                 except IndexError:
                     continue
                 error_message = line.split(project_id + ':')[1]
-                if line_number not in validation_errors.keys():
-                    validation_errors[line_number] = []
-                validation_errors[line_number].append(error_message)
+                if line_number not in validation_errors_server.keys():
+                    validation_errors_server[line_number] = []
+                validation_errors_server[line_number].append(error_message)
 
-        validation_error_str = {}
-        for line_num, errors in validation_errors.iteritems():
+        validation_errors = {}
+        for line_num, errors in validation_errors_server.iteritems():
             error_message = "<html><font face=\"verdana\" size=\"3\">"
             for error in errors:
                 error_message += "&#149; " + error + "<br/>"
             error_message += "</font></html>"
-            validation_error_str[line_num] = error_message
+            validation_errors[line_num] = error_message
 
-        return validation_error_str
+        # Refresh validation errors
+        self.atfAreaController.set_validation_errors(validation_errors)
 
     def printFile(self, event):
         '''

--- a/python/nammu/utils/NammuConsoleHandler.py
+++ b/python/nammu/utils/NammuConsoleHandler.py
@@ -31,6 +31,7 @@ class NammuConsoleHandler(StreamHandler):
         Needs a reference to nammu to be able to get ahold of Nammu's console.
         """
         super(logging.StreamHandler, self).__init__()
+        self.stream = None
         self.nammu_console = nammu_console
 
     def emit(self, record):

--- a/python/nammu/utils/NammuConsoleHandler.py
+++ b/python/nammu/utils/NammuConsoleHandler.py
@@ -31,7 +31,7 @@ class NammuConsoleHandler(StreamHandler):
         Needs a reference to nammu to be able to get ahold of Nammu's console.
         """
         super(logging.StreamHandler, self).__init__()
-        # Fixes an innocuous but ugly error message when existing Nammu.
+        # Fixes an innocuous but ugly error message when exiting Nammu.
         self.stream = None
         self.nammu_console = nammu_console
 

--- a/python/nammu/utils/NammuConsoleHandler.py
+++ b/python/nammu/utils/NammuConsoleHandler.py
@@ -30,7 +30,7 @@ class NammuConsoleHandler(StreamHandler):
         """
         Needs a reference to nammu to be able to get ahold of Nammu's console.
         """
-        super(logging.StreamHandler, self).__init__()\
+        super(logging.StreamHandler, self).__init__()
         # Fixes an innocuous but ugly error message when existing Nammu.
         self.stream = None
         self.nammu_console = nammu_console

--- a/python/nammu/utils/NammuConsoleHandler.py
+++ b/python/nammu/utils/NammuConsoleHandler.py
@@ -30,7 +30,8 @@ class NammuConsoleHandler(StreamHandler):
         """
         Needs a reference to nammu to be able to get ahold of Nammu's console.
         """
-        super(logging.StreamHandler, self).__init__()
+        super(logging.StreamHandler, self).__init__()\
+        # Fixes an innocuous but ugly error message when existing Nammu.
         self.stream = None
         self.nammu_console = nammu_console
 

--- a/python/nammu/view/AtfAreaView.py
+++ b/python/nammu/view/AtfAreaView.py
@@ -84,22 +84,38 @@ class AtfAreaView(JPanel):
         self.add(scrollingText, BorderLayout.CENTER)
 
         # Syntax highlight setup
-        sc = StyleContext.getDefaultStyleContext()
+        self.set_up_syntax_highlight()
+        
+        # Needs to be accessible from the AtfEditArea
+        self.validation_errors = None
+        
+    def set_up_syntax_highlight(self):
+        '''
+        Initialize colours, listeners and tokens to be syntax highlighted.
+        '''
         self.setup_syntax_highlight_colours()
-        self.attribs = {}
-        for color in self.colorlut:
+    
+        def get_attribs(color):
+            '''
+            Closure to make the generation of font styling cleaner.
+            Note closures need to be defined before being invoked.
+            '''
             attribs = SimpleAttributeSet()
             StyleConstants.setFontFamily(attribs,
                                          self.font.getFamily())
-            StyleConstants.setFontSize(attribs, self.font.getSize())
-            StyleConstants.setForeground(attribs, Color(*self.colorlut[color]))
-#             StyleConstants.setBackground(attribs, Color.yellow)
-            self.attribs[color] = attribs
+            StyleConstants.setFontSize(attribs, 
+                                       self.font.getSize())
+            StyleConstants.setForeground(attribs, 
+                                         Color(*self.colorlut[color]))
+            return attribs
+        
+        # Create a dictionary of attributes, two per possible font colour:
+        # one with yellow background for errors and another with default bg.
+        self.attribs = {}
+        for color in self.colorlut:
+            self.attribs[color] = get_attribs(color)
         self.editArea.addKeyListener(AtfAreaKeyListener(self))
         self.setup_syntax_highlight_tokens()
-
-        # Needs to be accessible from the AtfEditArea
-        self.validation_errors = None
 
     def error_highlight(self, validation_errors):
         """

--- a/python/nammu/view/AtfAreaView.py
+++ b/python/nammu/view/AtfAreaView.py
@@ -85,16 +85,16 @@ class AtfAreaView(JPanel):
 
         # Syntax highlight setup
         self.set_up_syntax_highlight()
-        
+
         # Needs to be accessible from the AtfEditArea
         self.validation_errors = {}
-        
+
     def set_up_syntax_highlight(self):
         '''
         Initialize colours, listeners and tokens to be syntax highlighted.
         '''
         self.setup_syntax_highlight_colours()
-    
+
         def get_attribs(color, error=False):
             '''
             Closure to make the generation of font styling cleaner.
@@ -103,9 +103,9 @@ class AtfAreaView(JPanel):
             attribs = SimpleAttributeSet()
             StyleConstants.setFontFamily(attribs,
                                          self.font.getFamily())
-            StyleConstants.setFontSize(attribs, 
+            StyleConstants.setFontSize(attribs,
                                        self.font.getSize())
-            StyleConstants.setForeground(attribs, 
+            StyleConstants.setForeground(attribs,
                                          Color(*self.colorlut[color]))
             # Add yellow background to error line styling
             # White if no error, otherwise it'll keep on being yellow forever
@@ -114,7 +114,7 @@ class AtfAreaView(JPanel):
             else:
                 StyleConstants.setBackground(attribs, Color.white)
             return attribs
-        
+
         # Create a dictionary of attributes, two per possible font colour:
         # one with yellow background for errors and another with default bg.
         self.attribs = {}
@@ -162,7 +162,9 @@ class AtfAreaView(JPanel):
                     textiter = re.finditer(r"\n", self.editArea.text)
                     line_num = int(line_num)
                     if line_num != 1:
-                        pos = [m.start() for m in textiter][line_num - 2:line_num]
+                        begin = line_num - 2
+                        end = line_num
+                        pos = [m.start() for m in textiter][begin:end]
                     else:
                         pos = [0, len(line)]
                     length = pos[1] - pos[0]
@@ -195,7 +197,7 @@ class AtfAreaView(JPanel):
             if str(line_num) in self.validation_errors.keys():
                 attribs = self.error_attribs[defaultcolor]
             else:
-                attribs = self.attribs[defaultcolor]    
+                attribs = self.attribs[defaultcolor]
             textiter = re.finditer(r"\n", text)
             if line_num != 1:
                 pos = [m.start() for m in textiter][line_num - 2:line_num]

--- a/python/nammu/view/AtfAreaView.py
+++ b/python/nammu/view/AtfAreaView.py
@@ -26,10 +26,8 @@ from javax.swing.text import SimpleAttributeSet
 from javax.swing.undo import UndoManager, CompoundEdit
 from javax.swing.event import UndoableEditListener
 from contextlib import contextmanager
-from pyoracc.atf.atflex import AtfLexer
 from .AtfEditArea import AtfEditArea
 from .LineNumbersArea import LineNumbersArea
-from ..utils import set_font
 
 
 class AtfAreaView(JPanel):
@@ -50,28 +48,20 @@ class AtfAreaView(JPanel):
         # window
         self.setLayout(BorderLayout())
 
-        # Set font
-        self.font = set_font()
-
-        # Create text edition area
-        self.editArea = AtfEditArea(self)
-
-        # Create text panel to display the line numbers
-        self.line_numbers_area = LineNumbersArea()
-
-        # Needed by syntax highlighter
-        self.edit_area_styledoc = self.editArea.getStyledDocument()
-        self.line_numbers_styledoc = self.line_numbers_area.getStyledDocument()
+        # Short hand for edit area and line numbers area
+        self.edit_area = self.controller.edit_area
+        self.line_numbers_area = self.controller.line_numbers_area
 
         # Set undo/redo manager to edit area
         self.undo_manager = UndoManager()
         self.undo_manager.limit = 3000
         self.edit_listener = AtfUndoableEditListener(self.undo_manager)
-        self.editArea.getDocument().addUndoableEditListener(self.edit_listener)
+        self.edit_area.getDocument().addUndoableEditListener(
+                                                        self.edit_listener)
 
         # Create panel that'll contain the ScrollPane and the line numbers
         container = JPanel(BorderLayout())
-        container.add(self.editArea, BorderLayout.CENTER)
+        container.add(self.edit_area, BorderLayout.CENTER)
         container.add(self.line_numbers_area, BorderLayout.WEST)
 
         # Will need scrolling controls that scroll line numbers and text lines
@@ -79,237 +69,11 @@ class AtfAreaView(JPanel):
         scrollingText = JScrollPane(container)
         scrollingText.setPreferredSize(Dimension(1, 500))
         scrollingText.getVerticalScrollBar().setUnitIncrement(16)
-
         # Add to parent panel
         self.add(scrollingText, BorderLayout.CENTER)
 
-        # Syntax highlight setup
-        self.set_up_syntax_highlight()
-
-        # Needs to be accessible from the AtfEditArea
-        self.validation_errors = {}
-
-    def set_up_syntax_highlight(self):
-        '''
-        Initialize colours, listeners and tokens to be syntax highlighted.
-        '''
-        self.setup_syntax_highlight_colours()
-
-        def get_attribs(color, error=False):
-            '''
-            Closure to make the generation of font styling cleaner.
-            Note closures need to be defined before being invoked.
-            '''
-            attribs = SimpleAttributeSet()
-            StyleConstants.setFontFamily(attribs,
-                                         self.font.getFamily())
-            StyleConstants.setFontSize(attribs,
-                                       self.font.getSize())
-            StyleConstants.setForeground(attribs,
-                                         Color(*self.colorlut[color]))
-            # Add yellow background to error line styling
-            # White if no error, otherwise it'll keep on being yellow forever
-            if error:
-                StyleConstants.setBackground(attribs, Color.yellow)
-            else:
-                StyleConstants.setBackground(attribs, Color.white)
-            return attribs
-
-        # Create a dictionary of attributes, two per possible font colour:
-        # one with yellow background for errors and another with default bg.
-        self.attribs = {}
-        self.error_attribs = {}
-        for color in self.colorlut:
-            self.attribs[color] = get_attribs(color)
-            self.error_attribs[color] = get_attribs(color, True)
-        self.editArea.addKeyListener(AtfAreaKeyListener(self))
-        self.setup_syntax_highlight_tokens()
-
-    def error_highlight(self, validation_errors):
-        """
-        Highlights line numbers and text lines that have errors.
-        Receives a dictionary with line numbers and error messages and repaints
-        the line numbers and text lines to highlight errors.
-        """
-        self.validation_errors = validation_errors
-        if validation_errors:
-            for line_num, error in validation_errors.items():
-                attribs = SimpleAttributeSet()
-                StyleConstants.setFontFamily(attribs, self.font.getFamily())
-                StyleConstants.setFontSize(attribs, self.font.getSize())
-                StyleConstants.setForeground(attribs, Color.red)
-                line_numbers_sd = self.line_numbers_area.getStyledDocument()
-                edit_area_sd = self.editArea.getStyledDocument()
-                text = self.line_numbers_area.text
-
-                # Search for start position and length of line number
-                if line_num in text:
-                    match = re.search(line_num, text)
-                    # This will return the position of the first substring
-                    # matching the line num, so we won't run into problems like
-                    # getting 122 when we are searching for 12 or 22.
-                    position = match.start()
-                    # Line numbers are as long as the number + 1 because it is
-                    # followed by a colon
-                    length = len(line_num) + 1
-                    # Change style in line number panel
-                    line_numbers_sd.setCharacterAttributes(position,
-                                                           length,
-                                                           attribs,
-                                                           True)
-
-                    # Calculate position of text line
-                    textiter = re.finditer(r"\n", self.editArea.text)
-                    line_num = int(line_num)
-                    if line_num != 1:
-                        begin = line_num - 2
-                        end = line_num
-                        pos = [m.start() for m in textiter][begin:end]
-                    else:
-                        pos = [0, len(line)]
-                    length = pos[1] - pos[0]
-                    # Highlight text line
-                    attribs = SimpleAttributeSet()
-                    StyleConstants.setFontFamily(attribs,
-                                                 self.font.getFamily())
-                    StyleConstants.setFontSize(attribs, self.font.getSize())
-                    StyleConstants.setBackground(attribs, Color.yellow)
-                    edit_area_sd.setCharacterAttributes(pos[0],
-                                                        length,
-                                                        attribs,
-                                                        True)
-
-    def syntax_highlight(self):
-        """
-        Implements syntax highlighting based on pyoracc.
-        """
-        lexer = AtfLexer(skipinvalid=True).lexer
-        edit_area_length = self.edit_area_styledoc.getLength()
-        text = self.edit_area_styledoc.getText(0,
-                                               edit_area_length)
-        splittext = text.split('\n')
-        lexer.input(text)
-        # Reset all styling
-        defaultcolor = self.tokencolorlu['default'][0]
-        # Keep background style from validation errors
-        line_num = 1
-        for line in splittext:
-            if str(line_num) in self.validation_errors.keys():
-                attribs = self.error_attribs[defaultcolor]
-            else:
-                attribs = self.attribs[defaultcolor]
-            textiter = re.finditer(r"\n", text)
-            if line_num != 1:
-                pos = [m.start() for m in textiter][line_num - 2:line_num]
-            else:
-                pos = [0, len(line)]
-            line_num += 1
-            self.edit_area_styledoc.setCharacterAttributes(pos[0],
-                                                           len(line) + 1,
-                                                           attribs,
-                                                           True)
-        for tok in lexer:
-            if tok.type in self.tokencolorlu:
-                if type(self.tokencolorlu[tok.type]) is dict:
-                    # the token should be styled differently depending
-                    # on state
-                    try:
-                        state = lexer.current_state()
-                        color = self.tokencolorlu[tok.type][state][0]
-                        styleline = self.tokencolorlu[tok.type][state][1]
-                    except KeyError:
-                        color = self.tokencolorlu['default'][0]
-                        styleline = self.tokencolorlu['default'][1]
-                else:
-                    color = self.tokencolorlu[tok.type][0]
-                    styleline = self.tokencolorlu[tok.type][1]
-                if styleline:
-                    mylength = len(splittext[tok.lineno-1])
-                else:
-                    mylength = len(tok.value)
-                if str(tok.lineno) in self.validation_errors.keys():
-                    attribs = self.error_attribs[color]
-                else:
-                    attribs = self.attribs[color]
-                self.edit_area_styledoc.setCharacterAttributes(tok.lexpos,
-                                                               mylength,
-                                                               attribs,
-                                                               True)
-
-    def setup_syntax_highlight_colours(self):
-        # Syntax highlighting colors based on SOLARIZED
-        self.colorlut = {}
-
-        # Black background tones
-        self.colorlut['base03'] = (0, 43, 54)
-        self.colorlut['base02'] = (7, 54, 66)
-
-        # Content tones
-        self.colorlut['base01'] = (88, 110, 117)
-        self.colorlut['base00'] = (101, 123, 131)
-        self.colorlut['base0'] = (131, 148, 150)
-        self.colorlut['base1'] = (147, 161, 161)
-
-        # White background tones
-        self.colorlut['base2'] = (238, 232, 213)
-        self.colorlut['base3'] = (253, 246, 227)
-
-        # Accent Colors
-        self.colorlut['yellow'] = (181, 137, 0)
-        self.colorlut['orange'] = (203, 75, 22)
-        self.colorlut['red'] = (220,  50, 47)
-        self.colorlut['magenta'] = (211,  54, 130)
-        self.colorlut['violet'] = (108, 113, 196)
-        self.colorlut['blue'] = (38, 139, 210)
-        self.colorlut['cyan'] = (42, 161, 152)
-        self.colorlut['green'] = (133, 153, 0)
-        self.colorlut['black'] = (0, 0, 0)
-
-    def setup_syntax_highlight_tokens(self):
-        self.tokencolorlu = {}
-        self.tokencolorlu['AMPERSAND'] = ('green', True)
-        for i in AtfLexer.protocols:
-            self.tokencolorlu[i] = ('magenta', False)
-        for i in AtfLexer.protocol_keywords:
-            self.tokencolorlu[i] = ('magenta', False)
-        for i in AtfLexer.structures:
-            self.tokencolorlu[i] = ('violet', False)
-        for i in AtfLexer.long_argument_structures:
-            self.tokencolorlu[i] = ('violet', False)
-        self.tokencolorlu['DOLLAR'] = ('orange', False)
-        for i in AtfLexer.dollar_keywords:
-            self.tokencolorlu[i] = ('orange', False)
-        self.tokencolorlu['REFERENCE'] = ('base01', False)
-        self.tokencolorlu['COMMENT'] = ('base1', True)
-        for i in AtfLexer.translation_keywords:
-            self.tokencolorlu[i] = ('green', False)
-        self.tokencolorlu['LINELABEL'] = ('yellow', False)
-        self.tokencolorlu['LEM'] = ('red', False)
-        self.tokencolorlu['SEMICOLON'] = ('red', False)
-        self.tokencolorlu['HAT'] = ('cyan', False)
-
-        self.tokencolorlu['NOTE'] = {}
-        self.tokencolorlu['NOTE']['flagged'] = ('violet', False)
-        self.tokencolorlu['NOTE']['para'] = ('magenta', False)
-
-        self.tokencolorlu['PROJECT'] = {}
-        self.tokencolorlu['PROJECT']['flagged'] = ('magenta', False)
-        self.tokencolorlu['PROJECT']['transctrl'] = ('green', False)
-        self.tokencolorlu['OPENR'] = ('green', False)
-        self.tokencolorlu['CLOSER'] = ('green', False)
-        self.tokencolorlu['default'] = ('black', False)
-
-    def repaint_line_numbers(self, n_lines):
-        """
-        Draws line numbers in corresponding panel.
-        """
-        # Create line numbers
-        numbers = ""
-        for line in range(n_lines + 1):
-            numbers += str(line + 1) + ": \n"
-
-        # Print in line numbers' area
-        self.line_numbers_area.setText(numbers)
+        # Ket listener that triggers syntax highlighting, etc. upon key release
+        self.edit_area.addKeyListener(AtfAreaKeyListener(self.controller))
 
 
 class AtfAreaKeyListener(KeyListener):
@@ -318,16 +82,16 @@ class AtfAreaKeyListener(KeyListener):
     line numbers (they'll need to be redrawn when a new line or block is added
     or removed).
     """
-    def __init__(self, atfareaview):
-        self.atfareaview = atfareaview
+    def __init__(self, controller):
+        self.controller = controller
 
     def keyReleased(self, ke):
-        self.atfareaview.syntax_highlight()
+        self.controller.syntax_highlight()
         # Check length hasn't changed, otherwise repaint line numbers
-        number_lines = self.atfareaview.line_numbers_area.text.count('\n')
-        text_lines = self.atfareaview.editArea.text.count('\n')
+        number_lines = self.controller.line_numbers_area.text.count('\n')
+        text_lines = self.controller.edit_area.text.count('\n')
         if number_lines - 1 != text_lines:
-            self.atfareaview.repaint_line_numbers(text_lines)
+            self.controller.repaint_line_numbers(text_lines)
 
     # We have to implement these since the baseclass versions
     # raise non implemented errors when called by the event.

--- a/python/nammu/view/AtfAreaView.py
+++ b/python/nammu/view/AtfAreaView.py
@@ -131,8 +131,8 @@ class AtfAreaView(JPanel):
         Receives a dictionary with line numbers and error messages and repaints
         the line numbers and text lines to highlight errors.
         """
+        self.validation_errors = validation_errors
         if validation_errors:
-            self.validation_errors = validation_errors
             for line_num, error in validation_errors.items():
                 attribs = SimpleAttributeSet()
                 StyleConstants.setFontFamily(attribs, self.font.getFamily())
@@ -158,17 +158,13 @@ class AtfAreaView(JPanel):
                                                            attribs,
                                                            True)
 
-                    # Calculate postion of text line
-                    text = re.finditer(r"\n", self.editArea.text)
+                    # Calculate position of text line
+                    textiter = re.finditer(r"\n", self.editArea.text)
                     line_num = int(line_num)
-                    if line_num >= 2:
-                        pos = [m.start() for m in text][line_num - 2:line_num]
-                    elif '\n' in self.editArea.text:
-                        # If error is in first line, highlight it
-                        pos = [0, self.editArea.text.index('\n')]
+                    if line_num != 1:
+                        pos = [m.start() for m in textiter][line_num - 2:line_num]
                     else:
-                        # If no end of line, text is a one liner
-                        pos = [0, len(self.editArea.text)]
+                        pos = [0, len(line)]
                     length = pos[1] - pos[0]
                     # Highlight text line
                     attribs = SimpleAttributeSet()
@@ -196,13 +192,18 @@ class AtfAreaView(JPanel):
         # Keep background style from validation errors
         line_num = 1
         for line in splittext:
-            if line_num in self.validation_errors.keys():
+            if str(line_num) in self.validation_errors.keys():
                 attribs = self.error_attribs[defaultcolor]
             else:
                 attribs = self.attribs[defaultcolor]    
+            textiter = re.finditer(r"\n", text)
+            if line_num != 1:
+                pos = [m.start() for m in textiter][line_num - 2:line_num]
+            else:
+                pos = [0, len(line)]
             line_num += 1
-            self.edit_area_styledoc.setCharacterAttributes(0,
-                                                           len(line),
+            self.edit_area_styledoc.setCharacterAttributes(pos[0],
+                                                           len(line) + 1,
                                                            attribs,
                                                            True)
         for tok in lexer:
@@ -224,7 +225,7 @@ class AtfAreaView(JPanel):
                     mylength = len(splittext[tok.lineno-1])
                 else:
                     mylength = len(tok.value)
-                if tok.lineno in self.validation_errors.keys():
+                if str(tok.lineno) in self.validation_errors.keys():
                     attribs = self.error_attribs[color]
                 else:
                     attribs = self.attribs[color]

--- a/python/nammu/view/AtfAreaView.py
+++ b/python/nammu/view/AtfAreaView.py
@@ -88,13 +88,15 @@ class AtfAreaView(JPanel):
         self.setup_syntax_highlight_colours()
         self.colors = {}
         for color in self.colorlut:
-            self.colors[color] = Color(*self.colorlut[color])
-            
+            self.colors[color] = sc.addAttribute(
+                                           SimpleAttributeSet.EMPTY,
+                                           StyleConstants.Foreground,
+                                           Color(*self.colorlut[color]))
         self.editArea.addKeyListener(AtfAreaKeyListener(self))
         self.setup_syntax_highlight_tokens()
-        
-        # Needs to be accessible from the AtfEditArea and syntax highlighter
-        self.validation_errors = {}
+
+        # Needs to be accessible from the AtfEditArea
+        self.validation_errors = None
 
     def error_highlight(self, validation_errors):
         """
@@ -129,7 +131,7 @@ class AtfAreaView(JPanel):
                                                            attribs,
                                                            True)
 
-                    # Calculate position of text line
+                    # Calculate postion of text line
                     text = re.finditer(r"\n", self.editArea.text)
                     line_num = int(line_num)
                     if line_num >= 2:
@@ -162,69 +164,37 @@ class AtfAreaView(JPanel):
                                                edit_area_length)
         splittext = text.split('\n')
         lexer.input(text)
+        # Reset all styling
         defaultcolor = self.tokencolorlu['default'][0]
         color = self.colors[defaultcolor]
-        
+        self.edit_area_styledoc.setCharacterAttributes(0,
+                                                       len(text),
+                                                       color,
+                                                       True)
         for tok in lexer:
-            defaultcolor = self.tokencolorlu['default'][0]
-            color = self.colors[defaultcolor]
-            if tok.lineno in self.validation_errors.keys():
-                if tok.type in self.tokencolorlu:
-                    if type(self.tokencolorlu[tok.type]) is dict:
-                        # the token should be styled differently depending
-                        # on state
-                        try:
-                            state = lexer.current_state()
-                            color = self.tokencolorlu[tok.type][state][0]
-                            styleline = self.tokencolorlu[tok.type][state][1]
-                        except KeyError:
-                            color = self.tokencolorlu['default'][0]
-                            styleline = self.tokencolorlu['default'][1]
-                    else:
-                        color = self.tokencolorlu[tok.type][0]
-                        styleline = self.tokencolorlu[tok.type][1]
-                    if styleline:
-                        mylength = len(splittext[tok.lineno-1])
-                    else:
-                        mylength = len(tok.value)
-                    attribs = SimpleAttributeSet()
-                    StyleConstants.setFontFamily(attribs, 
-                                                 self.font.getFamily())
-                    StyleConstants.setFontSize(attribs, self.font.getSize())
-                    StyleConstants.setForeground(attribs, self.colors[color])
-                    StyleConstants.setBackground(error_attribs, Color.yellow)
-                    self.edit_area_styledoc.setCharacterAttributes(tok.lexpos,
-                                                                   mylength,
-                                                                   attribs,
-                                                                   True)
-            else:
-                if tok.type in self.tokencolorlu:
-                    if isinstance(self.tokencolorlu[tok.type], dict):
-                        # the token should be styled differently depending
-                        # on state
-                        try:
-                            state = lexer.current_state()
-                            color = self.tokencolorlu[tok.type][state][0]
-                            styleline = self.tokencolorlu[tok.type][state][1]
-                        except KeyError:
-                            color = self.tokencolorlu['default'][0]
-                            styleline = self.tokencolorlu['default'][1]
-                    else:
-                        color = self.tokencolorlu[tok.type][0]
-                        styleline = self.tokencolorlu[tok.type][1]
-                    if styleline:
-                        mylength = len(splittext[tok.lineno-1])
-                    else:
-                        mylength = len(tok.value)
-                    attribs = SimpleAttributeSet()
-                    StyleConstants.setFontFamily(attribs, 
-                                                 self.font.getFamily())
-                    StyleConstants.setFontSize(attribs, self.font.getSize())
-                    StyleConstants.setForeground(attribs, self.colors[color])
-                    self.edit_area_styledoc.setCharacterAttributes(tok.lexpos,
-                                                                   mylength,
-                                                                   attribs,
-                                                                   True)
+            if tok.type in self.tokencolorlu:
+                if type(self.tokencolorlu[tok.type]) is dict:
+                    # the token should be styled differently depending
+                    # on state
+                    try:
+                        state = lexer.current_state()
+                        color = self.tokencolorlu[tok.type][state][0]
+                        styleline = self.tokencolorlu[tok.type][state][1]
+                    except KeyError:
+                        color = self.tokencolorlu['default'][0]
+                        styleline = self.tokencolorlu['default'][1]
+                else:
+                    color = self.tokencolorlu[tok.type][0]
+                    styleline = self.tokencolorlu[tok.type][1]
+                if styleline:
+                    mylength = len(splittext[tok.lineno-1])
+                else:
+                    mylength = len(tok.value)
+                color = self.colors[color]
+                self.edit_area_styledoc.setCharacterAttributes(tok.lexpos,
+                                                               mylength,
+                                                               color,
+                                                               True)
 
     def setup_syntax_highlight_colours(self):
         # Syntax highlighting colors based on SOLARIZED

--- a/python/nammu/view/AtfAreaView.py
+++ b/python/nammu/view/AtfAreaView.py
@@ -86,12 +86,15 @@ class AtfAreaView(JPanel):
         # Syntax highlight setup
         sc = StyleContext.getDefaultStyleContext()
         self.setup_syntax_highlight_colours()
-        self.colors = {}
+        self.attribs = {}
         for color in self.colorlut:
-            self.colors[color] = sc.addAttribute(
-                                           SimpleAttributeSet.EMPTY,
-                                           StyleConstants.Foreground,
-                                           Color(*self.colorlut[color]))
+            attribs = SimpleAttributeSet()
+            StyleConstants.setFontFamily(attribs,
+                                         self.font.getFamily())
+            StyleConstants.setFontSize(attribs, self.font.getSize())
+            StyleConstants.setForeground(attribs, Color(*self.colorlut[color]))
+#             StyleConstants.setBackground(attribs, Color.yellow)
+            self.attribs[color] = attribs
         self.editArea.addKeyListener(AtfAreaKeyListener(self))
         self.setup_syntax_highlight_tokens()
 
@@ -166,10 +169,10 @@ class AtfAreaView(JPanel):
         lexer.input(text)
         # Reset all styling
         defaultcolor = self.tokencolorlu['default'][0]
-        color = self.colors[defaultcolor]
+        attribs = self.attribs[defaultcolor]
         self.edit_area_styledoc.setCharacterAttributes(0,
                                                        len(text),
-                                                       color,
+                                                       attribs,
                                                        True)
         for tok in lexer:
             if tok.type in self.tokencolorlu:
@@ -190,10 +193,10 @@ class AtfAreaView(JPanel):
                     mylength = len(splittext[tok.lineno-1])
                 else:
                     mylength = len(tok.value)
-                color = self.colors[color]
+                attribs = self.attribs[color]
                 self.edit_area_styledoc.setCharacterAttributes(tok.lexpos,
                                                                mylength,
-                                                               color,
+                                                               attribs,
                                                                True)
 
     def setup_syntax_highlight_colours(self):

--- a/python/nammu/view/AtfAreaView.py
+++ b/python/nammu/view/AtfAreaView.py
@@ -193,11 +193,18 @@ class AtfAreaView(JPanel):
         lexer.input(text)
         # Reset all styling
         defaultcolor = self.tokencolorlu['default'][0]
-        attribs = self.attribs[defaultcolor]
-        self.edit_area_styledoc.setCharacterAttributes(0,
-                                                       len(text),
-                                                       attribs,
-                                                       True)
+        # Keep background style from validation errors
+        line_num = 1
+        for line in splittext:
+            if line_num in self.validation_errors.keys():
+                attribs = self.error_attribs[defaultcolor]
+            else:
+                attribs = self.attribs[defaultcolor]    
+            line_num += 1
+            self.edit_area_styledoc.setCharacterAttributes(0,
+                                                           len(line),
+                                                           attribs,
+                                                           True)
         for tok in lexer:
             if tok.type in self.tokencolorlu:
                 if type(self.tokencolorlu[tok.type]) is dict:

--- a/python/nammu/view/AtfEditArea.py
+++ b/python/nammu/view/AtfEditArea.py
@@ -49,7 +49,9 @@ class AtfEditArea(JTextPane):
                     err_msg = self.parent_component.validation_errors[line_num]
                 except KeyError:
                     # Current line has no error messages assigned
-                    pass
+                    # Returning None also switches off tooltips from previous
+                    # validation errors.
+                    return None
                 else:
                     return err_msg
 

--- a/python/nammu/view/AtfEditArea.py
+++ b/python/nammu/view/AtfEditArea.py
@@ -25,8 +25,8 @@ from ..utils import set_font
 
 class AtfEditArea(JTextPane):
 
-    def __init__(self, parent_component):
-        self.parent_component = parent_component
+    def __init__(self, controller):
+        self.controller = controller
         self.border = BorderFactory.createEmptyBorder(4, 4, 4, 4)
         self.font = set_font()
         # If this is not done, no tooltips appear
@@ -44,9 +44,9 @@ class AtfEditArea(JTextPane):
             position = self.viewToModel(event.getPoint())
             line_num = str(self.get_line_num(position))
             # Check if line_num has an error message assigned
-            if self.parent_component.validation_errors:
+            if self.controller.validation_errors:
                 try:
-                    err_msg = self.parent_component.validation_errors[line_num]
+                    err_msg = self.controller.validation_errors[line_num]
                 except KeyError:
                     # Current line has no error messages assigned
                     # Returning None also switches off tooltips from previous
@@ -68,7 +68,7 @@ class AtfEditArea(JTextPane):
         still works when you set text from elsewhere in the code.
         '''
         super(AtfEditArea, self).setText(text)
-        self.parent_component.syntax_highlight()
+        self.controller.syntax_highlight()
 
     def cut(self):
         '''
@@ -76,8 +76,8 @@ class AtfEditArea(JTextPane):
         works when user cuts text via toolbar button or mouse.
         '''
         super(AtfEditArea, self).cut()
-        self.parent_component.syntax_highlight()
-        self.parent_component.controller.update_line_numbers()
+        self.controller.syntax_highlight()
+        self.controller.update_line_numbers()
 
     def copy(self):
         '''
@@ -85,8 +85,8 @@ class AtfEditArea(JTextPane):
         works when user copies text via toolbar button or mouse.
         '''
         super(AtfEditArea, self).copy()
-        self.parent_component.syntax_highlight()
-        self.parent_component.controller.update_line_numbers()
+        self.controller.syntax_highlight()
+        self.controller.update_line_numbers()
 
     def paste(self):
         '''
@@ -94,8 +94,8 @@ class AtfEditArea(JTextPane):
         works when user pastes text via toolbar button or mouse.
         '''
         super(AtfEditArea, self).paste()
-        self.parent_component.syntax_highlight()
-        self.parent_component.controller.update_line_numbers()
+        self.controller.syntax_highlight()
+        self.controller.update_line_numbers()
 
 
 class CustomMouseListener(MouseAdapter):

--- a/python/nammu/view/AtfEditArea.py
+++ b/python/nammu/view/AtfEditArea.py
@@ -61,39 +61,39 @@ class AtfEditArea(JTextPane):
         """
         text = self.text[0:position]
         return text.count('\n') + 1
-    
+
     def setText(self, text):
         '''
-        Override JTextPane's setText to call syntax highlighting so that when 
-        you paste text via 
+        Override JTextPane's setText to call syntax highlighting so that it
+        still works when you set text from elsewhere in the code.
         '''
         super(AtfEditArea, self).setText(text)
         self.parent_component.syntax_highlight()
-        
+
     def cut(self):
         '''
-        Override JTextPane's cut to call syntax highlighting so that when 
-        you paste text via 
+        Override JTextPane's cut to call syntax highlighting so that it still
+        works when user cuts text via toolbar button or mouse.
         '''
         super(AtfEditArea, self).cut()
         self.parent_component.syntax_highlight()
-        
+
     def copy(self):
         '''
-        Override JTextPane's copy to call syntax highlighting so that when 
-        you paste text via 
+        Override JTextPane's copy to call syntax highlighting so that it still
+        works when user copies text via toolbar button or mouse.
         '''
         super(AtfEditArea, self).copy()
         self.parent_component.syntax_highlight()
-        
+
     def paste(self):
         '''
-        Override JTextPane's paste to call syntax highlighting so that when 
-        you paste text via 
+        Override JTextPane's paste to call syntax highlighting so that it still
+        works when user pastes text via toolbar button or mouse.
         '''
         super(AtfEditArea, self).paste()
         self.parent_component.syntax_highlight()
-        
+
 
 class CustomMouseListener(MouseAdapter):
     """

--- a/python/nammu/view/AtfEditArea.py
+++ b/python/nammu/view/AtfEditArea.py
@@ -69,6 +69,7 @@ class AtfEditArea(JTextPane):
         '''
         super(AtfEditArea, self).setText(text)
         self.controller.syntax_highlight()
+        self.controller.update_line_numbers()
 
     def cut(self):
         '''

--- a/python/nammu/view/AtfEditArea.py
+++ b/python/nammu/view/AtfEditArea.py
@@ -77,6 +77,7 @@ class AtfEditArea(JTextPane):
         '''
         super(AtfEditArea, self).cut()
         self.parent_component.syntax_highlight()
+        self.parent_component.controller.update_line_numbers()
 
     def copy(self):
         '''
@@ -85,6 +86,7 @@ class AtfEditArea(JTextPane):
         '''
         super(AtfEditArea, self).copy()
         self.parent_component.syntax_highlight()
+        self.parent_component.controller.update_line_numbers()
 
     def paste(self):
         '''
@@ -93,6 +95,7 @@ class AtfEditArea(JTextPane):
         '''
         super(AtfEditArea, self).paste()
         self.parent_component.syntax_highlight()
+        self.parent_component.controller.update_line_numbers()
 
 
 class CustomMouseListener(MouseAdapter):

--- a/python/nammu/view/AtfEditArea.py
+++ b/python/nammu/view/AtfEditArea.py
@@ -59,7 +59,39 @@ class AtfEditArea(JTextPane):
         """
         text = self.text[0:position]
         return text.count('\n') + 1
-
+    
+    def setText(self, text):
+        '''
+        Override JTextPane's setText to call syntax highlighting so that when 
+        you paste text via 
+        '''
+        super(AtfEditArea, self).setText(text)
+        self.parent_component.syntax_highlight()
+        
+    def cut(self):
+        '''
+        Override JTextPane's cut to call syntax highlighting so that when 
+        you paste text via 
+        '''
+        super(AtfEditArea, self).cut()
+        self.parent_component.syntax_highlight()
+        
+    def copy(self):
+        '''
+        Override JTextPane's copy to call syntax highlighting so that when 
+        you paste text via 
+        '''
+        super(AtfEditArea, self).copy()
+        self.parent_component.syntax_highlight()
+        
+    def paste(self):
+        '''
+        Override JTextPane's paste to call syntax highlighting so that when 
+        you paste text via 
+        '''
+        super(AtfEditArea, self).paste()
+        self.parent_component.syntax_highlight()
+        
 
 class CustomMouseListener(MouseAdapter):
     """

--- a/python/nammu/view/ConsoleView.py
+++ b/python/nammu/view/ConsoleView.py
@@ -44,21 +44,21 @@ class ConsoleView(JPanel):
         self.setLayout(BorderLayout())
 
         # Create console-looking area
-        self.editArea = JTextArea()
-        self.editArea.border = BorderFactory.createEmptyBorder(4, 4, 4, 4)
-        self.editArea.font = Font("Courier New", Font.BOLD, 14)
-        self.editArea.background = Color.BLACK
-        self.editArea.foreground = Color.WHITE
+        self.edit_area = JTextArea()
+        self.edit_area.border = BorderFactory.createEmptyBorder(4, 4, 4, 4)
+        self.edit_area.font = Font("Courier New", Font.BOLD, 14)
+        self.edit_area.background = Color.BLACK
+        self.edit_area.foreground = Color.WHITE
 
         # Disable writing in the console
-        self.editArea.setEditable(False)
+        self.edit_area.setEditable(False)
 
         # Will need scrolling controls
-        scrollingText = JScrollPane(self.editArea)
+        scrollingText = JScrollPane(self.edit_area)
         scrollingText.setPreferredSize(Dimension(1, 150))
 
         # Make text area auto scroll down to last printed line
-        caret = self.editArea.getCaret()
+        caret = self.edit_area.getCaret()
         caret.setUpdatePolicy(DefaultCaret.ALWAYS_UPDATE)
 
         # Add to parent panel
@@ -68,4 +68,5 @@ class ConsoleView(JPanel):
         '''
         Scroll down to bottom.
         '''
-        self.editArea.setCaretPosition(self.editArea.getDocument().getLength())
+        length = self.edit_area.getDocument().getLength()
+        self.edit_area.setCaretPosition(length)

--- a/python/nammu/view/SyntaxHighlighter.py
+++ b/python/nammu/view/SyntaxHighlighter.py
@@ -143,9 +143,12 @@ class SyntaxHighlighter:
         area_length = self.styledoc.getLength()
         text = self.styledoc.getText(0, area_length)
 
-        # Parse text
+        # Reset lexer and parse text
         self.lexer.input(text)
-
+        self.lexer.lineno = 1
+        while self.lexer.current_state() != 'INITIAL':
+            self.lexer.pop_state()
+            
         # Reset all styling
         defaultcolor = self.tokencolorlu['default'][0]
 
@@ -169,6 +172,7 @@ class SyntaxHighlighter:
                                                  len(line) + 1,
                                                  attribs,
                                                  True)
+            
         # Go through each token in the text, check which type it is to assign
         # a colour to it, check which position it is to set up default or
         # error background, etc.

--- a/python/nammu/view/SyntaxHighlighter.py
+++ b/python/nammu/view/SyntaxHighlighter.py
@@ -148,7 +148,7 @@ class SyntaxHighlighter:
         self.lexer.lineno = 1
         while self.lexer.current_state() != 'INITIAL':
             self.lexer.pop_state()
-            
+
         # Reset all styling
         defaultcolor = self.tokencolorlu['default'][0]
 
@@ -172,7 +172,7 @@ class SyntaxHighlighter:
                                                  len(line) + 1,
                                                  attribs,
                                                  True)
-            
+
         # Go through each token in the text, check which type it is to assign
         # a colour to it, check which position it is to set up default or
         # error background, etc.

--- a/python/nammu/view/SyntaxHighlighter.py
+++ b/python/nammu/view/SyntaxHighlighter.py
@@ -1,0 +1,201 @@
+'''
+Copyright 2015, 2016 University College London.
+
+This file is part of Nammu.
+
+Nammu is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Nammu is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Nammu.  If not, see <http://www.gnu.org/licenses/>.
+'''
+import re
+from pyoracc.atf.atflex import AtfLexer
+from java.awt import Color
+from javax.swing.text import StyleContext, StyleConstants
+from javax.swing.text import SimpleAttributeSet
+from ..utils import set_font
+
+
+class SyntaxHighlighter:
+    def __init__(self, controller):
+        self.controller = controller
+        self.setup_syntax_highlight_colours()
+        self.setup_syntax_highlight_tokens()
+        self.font = set_font()
+        self.setup_attribs()
+        self.styledoc = controller.edit_area_styledoc
+        self.lexer = AtfLexer(skipinvalid=True).lexer
+
+    def setup_attribs(self):
+        '''
+        Initialize colours, listeners and tokens to be syntax highlighted.
+        '''
+        def get_attribs(color, error=False):
+            '''
+            Closure to make the generation of font styling cleaner.
+            Note closures need to be defined before being invoked.
+            '''
+            attribs = SimpleAttributeSet()
+            StyleConstants.setFontFamily(attribs,
+                                         self.font.getFamily())
+            StyleConstants.setFontSize(attribs,
+                                       self.font.getSize())
+            StyleConstants.setForeground(attribs,
+                                         Color(*self.colorlut[color]))
+            # Add yellow background to error line styling
+            # White if no error, otherwise it'll keep on being yellow forever
+            if error:
+                StyleConstants.setBackground(attribs, Color.yellow)
+            else:
+                StyleConstants.setBackground(attribs, Color.white)
+            return attribs
+
+        # Create two dictionaries of attributes, one per possible bg colour:
+        # one with yellow background for errors and another with default bg.
+        self.attribs = {}
+        self.error_attribs = {}
+        for color in self.colorlut:
+            self.attribs[color] = get_attribs(color)
+            self.error_attribs[color] = get_attribs(color, True)
+
+    def setup_syntax_highlight_colours(self):
+        '''
+        Initialises the colour lookup table for syntax highlighting.
+        '''
+        # Syntax highlighting colors based on SOLARIZED
+        self.colorlut = {}
+
+        # Black background tones
+        self.colorlut['base03'] = (0, 43, 54)
+        self.colorlut['base02'] = (7, 54, 66)
+
+        # Content tones
+        self.colorlut['base01'] = (88, 110, 117)
+        self.colorlut['base00'] = (101, 123, 131)
+        self.colorlut['base0'] = (131, 148, 150)
+        self.colorlut['base1'] = (147, 161, 161)
+
+        # White background tones
+        self.colorlut['base2'] = (238, 232, 213)
+        self.colorlut['base3'] = (253, 246, 227)
+
+        # Accent Colors
+        self.colorlut['yellow'] = (181, 137, 0)
+        self.colorlut['orange'] = (203, 75, 22)
+        self.colorlut['red'] = (220,  50, 47)
+        self.colorlut['magenta'] = (211,  54, 130)
+        self.colorlut['violet'] = (108, 113, 196)
+        self.colorlut['blue'] = (38, 139, 210)
+        self.colorlut['cyan'] = (42, 161, 152)
+        self.colorlut['green'] = (133, 153, 0)
+        self.colorlut['black'] = (0, 0, 0)
+
+    def setup_syntax_highlight_tokens(self):
+        '''
+        Assings colours depending on type of token.
+        '''
+        self.tokencolorlu = {}
+        self.tokencolorlu['AMPERSAND'] = ('green', True)
+        for i in AtfLexer.protocols:
+            self.tokencolorlu[i] = ('magenta', False)
+        for i in AtfLexer.protocol_keywords:
+            self.tokencolorlu[i] = ('magenta', False)
+        for i in AtfLexer.structures:
+            self.tokencolorlu[i] = ('violet', False)
+        for i in AtfLexer.long_argument_structures:
+            self.tokencolorlu[i] = ('violet', False)
+        self.tokencolorlu['DOLLAR'] = ('orange', False)
+        for i in AtfLexer.dollar_keywords:
+            self.tokencolorlu[i] = ('orange', False)
+        self.tokencolorlu['REFERENCE'] = ('base01', False)
+        self.tokencolorlu['COMMENT'] = ('base1', True)
+        for i in AtfLexer.translation_keywords:
+            self.tokencolorlu[i] = ('green', False)
+        self.tokencolorlu['LINELABEL'] = ('yellow', False)
+        self.tokencolorlu['LEM'] = ('red', False)
+        self.tokencolorlu['SEMICOLON'] = ('red', False)
+        self.tokencolorlu['HAT'] = ('cyan', False)
+
+        self.tokencolorlu['NOTE'] = {}
+        self.tokencolorlu['NOTE']['flagged'] = ('violet', False)
+        self.tokencolorlu['NOTE']['para'] = ('magenta', False)
+
+        self.tokencolorlu['PROJECT'] = {}
+        self.tokencolorlu['PROJECT']['flagged'] = ('magenta', False)
+        self.tokencolorlu['PROJECT']['transctrl'] = ('green', False)
+        self.tokencolorlu['OPENR'] = ('green', False)
+        self.tokencolorlu['CLOSER'] = ('green', False)
+        self.tokencolorlu['default'] = ('black', False)
+
+    def syntax_highlight(self):
+        '''
+        Implements syntax highlighting based on pyoracc.
+        '''
+        # Get text from styledoc
+        area_length = self.styledoc.getLength()
+        text = self.styledoc.getText(0, area_length)
+
+        # Parse text
+        self.lexer.input(text)
+
+        # Reset all styling
+        defaultcolor = self.tokencolorlu['default'][0]
+
+        # Break test into separate lines
+        splittext = text.split('\n')
+
+        # Keep background style from validation errors
+        line_num = 1
+        for line in splittext:
+            if str(line_num) in self.controller.validation_errors.keys():
+                attribs = self.error_attribs[defaultcolor]
+            else:
+                attribs = self.attribs[defaultcolor]
+            textiter = re.finditer(r"\n", text)
+            if line_num != 1:
+                pos = [m.start() for m in textiter][line_num - 2:line_num]
+            else:
+                pos = [0, len(line)]
+            line_num += 1
+            self.styledoc.setCharacterAttributes(pos[0],
+                                                 len(line) + 1,
+                                                 attribs,
+                                                 True)
+        # Go through each token in the text, check which type it is to assign
+        # a colour to it, check which position it is to set up default or
+        # error background, etc.
+        for tok in self.lexer:
+            if tok.type in self.tokencolorlu:
+                if type(self.tokencolorlu[tok.type]) is dict:
+                    # the token should be styled differently depending
+                    # on state
+                    try:
+                        state = self.lexer.current_state()
+                        color = self.tokencolorlu[tok.type][state][0]
+                        styleline = self.tokencolorlu[tok.type][state][1]
+                    except KeyError:
+                        color = self.tokencolorlu['default'][0]
+                        styleline = self.tokencolorlu['default'][1]
+                else:
+                    color = self.tokencolorlu[tok.type][0]
+                    styleline = self.tokencolorlu[tok.type][1]
+                if styleline:
+                    mylength = len(splittext[tok.lineno-1])
+                else:
+                    mylength = len(tok.value)
+                if str(tok.lineno) in self.controller.validation_errors.keys():
+                    attribs = self.error_attribs[color]
+                else:
+                    attribs = self.attribs[color]
+                self.styledoc.setCharacterAttributes(tok.lexpos,
+                                                     mylength,
+                                                     attribs,
+                                                     True)


### PR DESCRIPTION
Rewrite of `syntax_highlight` so it covers error highlighting as well, so we can simplify the code a little bit and make error highlight persistent.
Also fixed the tooltip clearing functionality.

Still needs some refactoring, so please don't merge yet.