### PR TITLE
Avoid syntax highlight when keyReleased is an action key or ctrl, cmd…

### DIFF
--- a/python/nammu/view/AtfAreaView.py
+++ b/python/nammu/view/AtfAreaView.py
@@ -89,8 +89,8 @@ class AtfAreaKeyListener(KeyListener):
         # Make sure we only syntax highlight when the key pressed is not an
         # action key (i.e. arrows, F1, ...) or is not shift, ctrl, alt, caps
         # lock or cmd.
-        if ((not ke.isActionKey()) and 
-            (ke.getKeyCode() not in (16, 17, 18, 20, 157))):
+        if ((not ke.isActionKey()) and
+                (ke.getKeyCode() not in (16, 17, 18, 20, 157))):
             self.controller.syntax_highlight()
             # Check length hasn't changed, otherwise repaint line numbers
             number_lines = self.controller.line_numbers_area.text.count('\n')

--- a/python/nammu/view/AtfAreaView.py
+++ b/python/nammu/view/AtfAreaView.py
@@ -86,12 +86,17 @@ class AtfAreaKeyListener(KeyListener):
         self.controller = controller
 
     def keyReleased(self, ke):
-        self.controller.syntax_highlight()
-        # Check length hasn't changed, otherwise repaint line numbers
-        number_lines = self.controller.line_numbers_area.text.count('\n')
-        text_lines = self.controller.edit_area.text.count('\n')
-        if number_lines - 1 != text_lines:
-            self.controller.repaint_line_numbers(text_lines)
+        # Make sure we only syntax highlight when the key pressed is not an
+        # action key (i.e. arrows, F1, ...) or is not shift, ctrl, alt, caps
+        # lock or cmd.
+        if ((not ke.isActionKey()) and 
+            (ke.getKeyCode() not in (16, 17, 18, 20, 157))):
+            self.controller.syntax_highlight()
+            # Check length hasn't changed, otherwise repaint line numbers
+            number_lines = self.controller.line_numbers_area.text.count('\n')
+            text_lines = self.controller.edit_area.text.count('\n')
+            if number_lines - 1 != text_lines:
+                self.controller.repaint_line_numbers(text_lines)
 
     # We have to implement these since the baseclass versions
     # raise non implemented errors when called by the event.


### PR DESCRIPTION
…, alt, etc.

Helps with problem reported in #157.