### PR TITLE
Bugfix saveasfile displays wrong log message

### DIFF
--- a/python/nammu/controller/NammuController.py
+++ b/python/nammu/controller/NammuController.py
@@ -241,17 +241,18 @@ class NammuController(object):
                             "Confirm replace file",
                             JOptionPane.YES_NO_OPTION)
                 if reply == JOptionPane.NO_OPTION:
+                    print("tal")
                     return
             self.currentFilename = filename
             self.view.setTitle(basename)
-        try:
-            self.writeTextFile(self.currentFilename, atfText)
-        except:
-            self.logger.error("There was an error trying to save %s.",
-                              self.currentFilename)
-        else:
-            self.logger.info("File %s successfully saved.",
-                             self.currentFilename)
+            try:
+                self.writeTextFile(self.currentFilename, atfText)
+            except:
+                self.logger.error("There was an error trying to save %s.",
+                                  self.currentFilename)
+            else:
+                self.logger.info("File %s successfully saved.",
+                                 self.currentFilename)
 
         # Find project and add to setting.yaml as default
         project = self.get_project()

--- a/python/nammu/controller/NammuController.py
+++ b/python/nammu/controller/NammuController.py
@@ -241,7 +241,6 @@ class NammuController(object):
                             "Confirm replace file",
                             JOptionPane.YES_NO_OPTION)
                 if reply == JOptionPane.NO_OPTION:
-                    print("tal")
                     return
             self.currentFilename = filename
             self.view.setTitle(basename)


### PR DESCRIPTION
When saving as, then canceling from the JFileChooser, the current file is overwritten and a log message appears saying "File ... successfully saved."