### PR TITLE
Bugfix/missing file

### DIFF
--- a/python/nammu/controller/NammuController.py
+++ b/python/nammu/controller/NammuController.py
@@ -315,6 +315,8 @@ class NammuController(object):
                 else:
                     return False
             else:
+                # Clear previous log in Nammu's console and write warning
+                self.consoleController.clearConsole()
                 self.logger.info('{0} cannot be found.'
                                  .format(self.currentFilename))
                 return True

--- a/python/nammu/controller/NammuController.py
+++ b/python/nammu/controller/NammuController.py
@@ -308,11 +308,16 @@ class NammuController(object):
         nammuText = self.atfAreaController.getAtfAreaText()
 
         if self.currentFilename:
-            savedText = self.readTextFile(self.currentFilename)
-            if savedText != nammuText:
-                return True
+            if os.path.isfile(self.currentFilename):
+                savedText = self.readTextFile(self.currentFilename)
+                if savedText != nammuText:
+                    return True
+                else:
+                    return False
             else:
-                return False
+                self.logger.info('{0} cannot be found.'
+                                 .format(self.currentFilename))
+
         elif nammuText:
             return True
 

--- a/python/nammu/controller/NammuController.py
+++ b/python/nammu/controller/NammuController.py
@@ -317,6 +317,7 @@ class NammuController(object):
             else:
                 self.logger.info('{0} cannot be found.'
                                  .format(self.currentFilename))
+                return True
 
         elif nammuText:
             return True


### PR DESCRIPTION
This is a simple fix where if the current filename is not `None` we use `os.path` to check if the file actually exists. If it does not, a message is posted to the console warning the user that the file cannot be found and the `handleUnsaved` routine is called to open the save dialogue in the same manner as if the user tried to exit without saving changes.

<img width="698" alt="screen shot 2017-06-09 at 16 18 12" src="https://user-images.githubusercontent.com/10617231/26982127-4d0e4b94-4d2f-11e7-81ea-57820253c8b4.png">
