### PR TITLE
Stop the cursor jumping to the end of a file

### DIFF
--- a/python/nammu/controller/NammuController.py
+++ b/python/nammu/controller/NammuController.py
@@ -425,6 +425,9 @@ class NammuController(object):
         Connect to ORACC server and retrieved lemmatised version of ATF file.
         Don't lemmatise if file doesn't validate.
         '''
+        # Grab the caret position before lemmatising
+        pre_cursor = self.atfAreaController.edit_area.getCaretPosition()
+
         # Clear previous log in Nammu's console
         self.consoleController.clearConsole()
 
@@ -447,6 +450,9 @@ class NammuController(object):
                                 self.currentFilename)
 
             self.logger.debug("Lemmatising ATF done.")
+
+            # Restore the caret position following lemmatisation
+            self.atfAreaController.edit_area.setCaretPosition(pre_cursor)
         else:
             self.logger.error("Please save file before trying to lemmatise.")
 

--- a/python/nammu/controller/NammuController.py
+++ b/python/nammu/controller/NammuController.py
@@ -158,6 +158,8 @@ class NammuController(object):
                 self.atfAreaController.setAtfAreaText(atfText)
                 self.logger.debug("File %s successfully opened.", filename)
                 self.view.setTitle(basename)
+                # Reset the caret position to the top of the file
+                self.atfAreaController.edit_area.setCaretPosition(0)
 
             # TODO: Else, prompt user to choose again before closing
 


### PR DESCRIPTION
See issue #259: Have added a variable to record the caret position prior to lemmatisation, and restore it following the completion of lemmatisation.

In some cases will still cause a small screen scroll as the `setCaretPosition()` method always tries to centre the cursor in the viewport. But considering that lemmatisation will insert lines into the document I think this is an ok compromise.

I have also used similar logic to stop nammu scrolling to the end of files when they are first loaded.