### PR TITLE
Error highlight 243

### DIFF
--- a/python/nammu/controller/AtfAreaController.py
+++ b/python/nammu/controller/AtfAreaController.py
@@ -219,6 +219,10 @@ class AtfAreaController(object):
 
         return bottom_left_char
 
+    def update_error_lines_insert(self, caret_line, no_of_newlines):
+        print 'newlines', no_of_newlines
+        print 'caret_line', caret_line
+
     def syntax_highlight(self, top_caret=None, bottom_caret=None):
         '''
         Short hand for syntax highlighting. Takes the line bounds.

--- a/python/nammu/controller/AtfAreaController.py
+++ b/python/nammu/controller/AtfAreaController.py
@@ -249,39 +249,22 @@ class AtfAreaController(object):
         if caret_line > max(e_lines_int):
             return
 
+        # We need the line end position and the caret position
+        positions = self.getLinePositions(self.view.oldtext)
+        caret_pos = self.edit_area.getCaretPosition()
+        line_end = positions[caret_line - 1][1]
+
         tmp = {}
         for q, err in enumerate(e_lines_int):
-
-            # The easiest case, we are above an error line
-            if err > caret_line:
+            # We are above an error line or on an error line but not at its end
+            if (err > caret_line) or (err == caret_line and caret_pos != line_end):
                 fixed_line_no = self.line_fix(e_lines_int[q], no_of_lines,
                                               flag)
 
                 # rebuild self.controller.validation_errors
                 tmp[str(fixed_line_no)] = self.validation_errors[str(err)]
 
-            # Edge case - we are on the error line
-            elif err == caret_line:
-
-                # We need the line end position and the caret position
-                positions = self.getLinePositions(self.view.oldtext)
-                caret_pos = self.edit_area.getCaretPosition()
-                line_end = positions[caret_line - 1][1]
-
-                # If we are not at the end of a line, update the highlighting
-                if caret_pos != line_end:
-
-                    fixed_line_no = self.line_fix(e_lines_int[q],
-                                                  no_of_lines,
-                                                  flag)
-
-                    # rebuild self.controller.validation_errors
-                    tmp[str(fixed_line_no)] = self.validation_errors[str(err)]
-                else:
-                    # We are at the end of a line, so an insert will not alter
-                    # the error line's position
-                    tmp[str(err)] = self.validation_errors[str(err)]
-            # We are below the error line so do nothing
+            # We are below or after the error lines so do nothing
             else:
                 tmp[str(err)] = self.validation_errors[str(err)]
 

--- a/python/nammu/controller/AtfAreaController.py
+++ b/python/nammu/controller/AtfAreaController.py
@@ -257,7 +257,8 @@ class AtfAreaController(object):
         tmp = {}
         for q, err in enumerate(e_lines_int):
             # We are above an error line or on an error line but not at its end
-            if (err > caret_line) or (err == caret_line and caret_pos != line_end):
+            if (err > caret_line) or (err == caret_line and
+                                      caret_pos != line_end):
                 fixed_line_no = self.line_fix(e_lines_int[q], no_of_lines,
                                               flag)
 

--- a/python/nammu/controller/AtfAreaController.py
+++ b/python/nammu/controller/AtfAreaController.py
@@ -267,7 +267,7 @@ class AtfAreaController(object):
                 positions = self.getLinePositions(self.view.oldtext)
                 caret_pos = self.edit_area.getCaretPosition()
                 line_end = positions[caret_line - 1][1]
-                
+
                 # If we are not at the end of a line, update the highlighting
                 if caret_pos != line_end:
 

--- a/python/nammu/controller/AtfAreaController.py
+++ b/python/nammu/controller/AtfAreaController.py
@@ -224,9 +224,6 @@ class AtfAreaController(object):
         if no_of_newlines < 1:
             return
 
-        if self.validation_errors == {}:
-            return
-
         error_lines = self.validation_errors.keys()
 
         error_lines_int = [int(a) for a in error_lines]
@@ -243,7 +240,26 @@ class AtfAreaController(object):
 
             self.validation_errors = tmp
 
-            top_l_char, bottom_l_char = self.view.get_viewport_carets()
+    def update_error_lines_remove(self, caret_line, no_of_removed_lines):
+
+        if no_of_removed_lines < 1:
+            return
+
+        error_lines = self.validation_errors.keys()
+
+        error_lines_int = [int(a) for a in error_lines]
+
+        if caret_line < min(error_lines_int):
+
+            tmp = {}
+            for q, err in enumerate(error_lines_int):
+                if err > caret_line:
+                    error_lines_int[q] -= no_of_removed_lines
+
+                    # rebuild self.controller.validation_errors.keys()
+                    tmp[str(error_lines_int[q])] = self.validation_errors[str(err)]
+
+            self.validation_errors = tmp
 
     def syntax_highlight(self, top_caret=None, bottom_caret=None):
         '''

--- a/python/nammu/controller/AtfAreaController.py
+++ b/python/nammu/controller/AtfAreaController.py
@@ -243,22 +243,22 @@ class AtfAreaController(object):
         error_lines = self.validation_errors.keys()
 
         # For legacy reasons the keys are strings, but we need ints
-        error_lines_int = [int(a) for a in error_lines]
+        e_lines_int = [int(a) for a in error_lines]
 
         # We only care about edits hapenning above error lines
         if caret_line < max(error_lines_int):
 
             tmp = {}
-            for q, err in enumerate(error_lines_int):
+            for q, err in enumerate(e_lines_int):
                 if err > caret_line:
                     # either increment or decrement based on insert or remove
                     if flag == 'insert':
-                        error_lines_int[q] += no_of_lines
+                        e_lines_int[q] += no_of_lines
                     elif flag == 'remove':
-                        error_lines_int[q] -= no_of_lines
+                        e_lines_int[q] -= no_of_lines
 
                     # rebuild self.controller.validation_errors.keys()
-                    tmp[str(error_lines_int[q])] = self.validation_errors[str(err)]
+                    tmp[str(e_lines_int[q])] = self.validation_errors[str(err)]
 
             self.validation_errors = tmp
 

--- a/python/nammu/controller/AtfAreaController.py
+++ b/python/nammu/controller/AtfAreaController.py
@@ -220,8 +220,30 @@ class AtfAreaController(object):
         return bottom_left_char
 
     def update_error_lines_insert(self, caret_line, no_of_newlines):
-        print 'newlines', no_of_newlines
-        print 'caret_line', caret_line
+
+        if no_of_newlines < 1:
+            return
+
+        if self.validation_errors == {}:
+            return
+
+        error_lines = self.validation_errors.keys()
+
+        error_lines_int = [int(a) for a in error_lines]
+
+        if caret_line < min(error_lines_int):
+
+            tmp = {}
+            for q, err in enumerate(error_lines_int):
+                if err > caret_line:
+                    error_lines_int[q] += no_of_newlines
+
+                    # rebuild self.controller.validation_errors.keys()
+                    tmp[str(error_lines_int[q])] = self.validation_errors[str(err)]
+
+            self.validation_errors = tmp
+
+            top_l_char, bottom_l_char = self.view.get_viewport_carets()
 
     def syntax_highlight(self, top_caret=None, bottom_caret=None):
         '''

--- a/python/nammu/controller/AtfAreaController.py
+++ b/python/nammu/controller/AtfAreaController.py
@@ -155,6 +155,10 @@ class AtfAreaController(object):
         return top_line, bottom_line
 
     def pad_top_viewport_caret(self, top_left_char, text):
+        '''
+        Extend the top of the viewport to the nearest header, so we don't
+        have problems with malformed atf files being highlighted.
+        '''
 
         # Test that there is text in the edit area
         if len(text) == 0:
@@ -198,6 +202,10 @@ class AtfAreaController(object):
             return top_left_char
 
     def pad_bottom_viewport_caret(self, bottom_left_char, text):
+        '''
+        Adds two lines to the bottom of the viewport so we dont have any
+        unhighlighted lines visible.
+        '''
 
         # Test that there is text in the edit area
         if len(text) == 0:
@@ -219,42 +227,35 @@ class AtfAreaController(object):
 
         return bottom_left_char
 
-    def update_error_lines_insert(self, caret_line, no_of_newlines):
+    def update_error_lines(self, caret_line, no_of_lines, flag):
+        '''
+        Given a caret line number, a number of lines and a flag indicating
+        whether the error lines need incremented ('insert') or decremented
+        ('remove'). Update the line numbers of the keys in the dictionary
+        self.validation_errors so that error highlighting follows broken lines
+        during editing.
+        '''
 
-        if no_of_newlines < 1:
+        # If the supplied edit does not add or remove any lines, do nothing
+        if no_of_lines < 1:
             return
 
         error_lines = self.validation_errors.keys()
 
+        # For legacy reasons the keys are strings, but we need ints
         error_lines_int = [int(a) for a in error_lines]
 
-        if caret_line < min(error_lines_int):
+        # We only care about edits hapenning above error lines
+        if caret_line < max(error_lines_int):
 
             tmp = {}
             for q, err in enumerate(error_lines_int):
                 if err > caret_line:
-                    error_lines_int[q] += no_of_newlines
-
-                    # rebuild self.controller.validation_errors.keys()
-                    tmp[str(error_lines_int[q])] = self.validation_errors[str(err)]
-
-            self.validation_errors = tmp
-
-    def update_error_lines_remove(self, caret_line, no_of_removed_lines):
-
-        if no_of_removed_lines < 1:
-            return
-
-        error_lines = self.validation_errors.keys()
-
-        error_lines_int = [int(a) for a in error_lines]
-
-        if caret_line < min(error_lines_int):
-
-            tmp = {}
-            for q, err in enumerate(error_lines_int):
-                if err > caret_line:
-                    error_lines_int[q] -= no_of_removed_lines
+                    # either increment or decrement based on insert or remove
+                    if flag == 'insert':
+                        error_lines_int[q] += no_of_lines
+                    elif flag == 'remove':
+                        error_lines_int[q] -= no_of_lines
 
                     # rebuild self.controller.validation_errors.keys()
                     tmp[str(error_lines_int[q])] = self.validation_errors[str(err)]

--- a/python/nammu/view/AtfAreaView.py
+++ b/python/nammu/view/AtfAreaView.py
@@ -291,10 +291,6 @@ class AtfUndoableEditListener(UndoableEditListener):
         edit = event.getEdit()
         edit_type = str(edit.getType())
 
-        if edit_type == "REMOVE":
-            # This could be a place where we can get info about the removed text
-            pass
-
         # If significant INSERT/REMOVE event happen, end and add current
         # edit compound to undo_manager and start a new one.
         if ((edit_type == "INSERT" or edit_type == "REMOVE") and

--- a/python/nammu/view/AtfAreaView.py
+++ b/python/nammu/view/AtfAreaView.py
@@ -81,6 +81,9 @@ class AtfAreaView(JPanel):
         # Add a document listener to track changes to files
         self.edit_area.getDocument().addDocumentListener(atfAreaDocumentListener(self))
 
+        # instance variable to store a record of the text contents prior to the
+        # most recent change. Needed so that the different listeners can access
+        # this to handle error line updating.
         self.oldtext = ''
 
     def toggle_split(self, split_orientation=None):

--- a/python/nammu/view/AtfAreaView.py
+++ b/python/nammu/view/AtfAreaView.py
@@ -79,7 +79,8 @@ class AtfAreaView(JPanel):
         self.secondary_area.addKeyListener(AtfAreaKeyListener(self))
 
         # Add a document listener to track changes to files
-        self.edit_area.getDocument().addDocumentListener(atfAreaDocumentListener(self))
+        docListener = atfAreaDocumentListener(self)
+        self.edit_area.getDocument().addDocumentListener(docListener)
 
         # instance variable to store a record of the text contents prior to the
         # most recent change. Needed so that the different listeners can access
@@ -158,10 +159,11 @@ class atfAreaDocumentListener(DocumentListener):
         self.areaviewcontroller = areaview.controller
         self.areaview = areaview
 
-
     def errorUpdate(self, e, text, flag):
         '''
         Method to handle the updating of error lines.
+        flag indicates whether the error lines need incremented ('insert')
+        or decrmented ('remove').
         '''
 
         # Only need to do this if we have error_lines

--- a/python/nammu/view/AtfAreaView.py
+++ b/python/nammu/view/AtfAreaView.py
@@ -158,53 +158,54 @@ class atfAreaDocumentListener(DocumentListener):
         self.areaviewcontroller = areaview.controller
         self.areaview = areaview
 
-    def changedUpdate(self, e):
-        pass
 
-    def insertUpdate(self, e):
-
-        # Only need to do this if we have error lines
-        if self.areaviewcontroller.validation_errors == {}:
-            return
-
-        text = self.areaviewcontroller.edit_area.getText()
-        length = e.getLength()
-        offset = e.getOffset()
-
-        insert = text[offset:length + offset]
-
-        if '\n' in insert:
-            no_of_newlines = insert.count('\n')
-
-            # Get the line no of the caret postion
-            caret_line = self.areaviewcontroller.edit_area.get_line_num(offset)
-
-            # Call our error line update method here, passing no_of_newlines
-            self.areaviewcontroller.update_error_lines_insert(caret_line,
-                                                              no_of_newlines)
-
-    def removeUpdate(self, e):
+    def errorUpdate(self, e, text, flag):
+        '''
+        Method to handle the updating of error lines.
+        '''
 
         # Only need to do this if we have error_lines
         if self.areaviewcontroller.validation_errors == {}:
             return
 
-        text = self.areaview.oldtext
+        # Gets the position and length of the edit to the document
         length = e.getLength()
         offset = e.getOffset()
 
-        removed = text[offset:length + offset]
+        # Slice out the edited text
+        edited = text[offset:length + offset]
 
-        if '\n' in removed:
-            no_removed_lines = removed.count('\n')
+        if '\n' in edited:
+            no_of_newlines = edited.count('\n')
 
             # Get the line no of the caret postion
             caret_line = self.areaviewcontroller.edit_area.get_line_num(offset)
 
-            # Call our error line update method here, passing no_removed_lines
-            self.areaviewcontroller.update_error_lines_remove(caret_line,
-                                                              no_removed_lines)
+            # Call our error line update method here, passing no_of_newlines
+            self.areaviewcontroller.update_error_lines(caret_line,
+                                                       no_of_newlines,
+                                                       flag)
 
+    def changedUpdate(self, e):
+        '''
+        Must be implemented to avoid NotImplemented errors
+        '''
+        pass
+
+    def insertUpdate(self, e):
+        '''
+        Listen for an insertion to the document.
+        '''
+        text = self.areaviewcontroller.edit_area.getText()
+        self.errorUpdate(e, text, 'insert')
+
+    def removeUpdate(self, e):
+        '''
+        Listen for a removal from the document
+        '''
+        # Get the text prior to this edit event
+        text = self.areaview.oldtext
+        self.errorUpdate(e, text, 'remove')
 
 
 class atfAreaAdjustmentListener(AdjustmentListener):

--- a/python/nammu/view/AtfEditArea.py
+++ b/python/nammu/view/AtfEditArea.py
@@ -90,7 +90,6 @@ class AtfEditArea(JTextPane):
         after replacing some text.
         '''
         super(AtfEditArea, self).replaceSelection(text)
-        self.controller.syntax_highlight()
 
     def cut(self):
         '''
@@ -98,7 +97,6 @@ class AtfEditArea(JTextPane):
         works when user cuts text via toolbar button or mouse.
         '''
         super(AtfEditArea, self).cut()
-        self.controller.syntax_highlight()
 
     def copy(self):
         '''
@@ -106,7 +104,6 @@ class AtfEditArea(JTextPane):
         works when user copies text via toolbar button or mouse.
         '''
         super(AtfEditArea, self).copy()
-        self.controller.syntax_highlight()
 
     def paste(self):
         '''
@@ -114,7 +111,6 @@ class AtfEditArea(JTextPane):
         works when user pastes text via toolbar button or mouse.
         '''
         super(AtfEditArea, self).paste()
-        self.controller.syntax_highlight()
 
 
 class CustomMouseListener(MouseAdapter):


### PR DESCRIPTION
Fixing the issue of error highlighting not persisting on line insertion or deletion, as reported in #243.

Resolved by using a document listener to get changes to a text area, and where there are newlines in those changes, update the dictionary of error lines from the server to reflect the new document structure. For the case of deleted lines it is a bit more messy, as we have to use the keypress listener to record the contents of the text area prior to an edit occurring, and then use the document listener to identify the removed text and then do the same process as with the added text, but decreasing line numbers in the dictionary.

### Still to do

- [x] Refactor the code as there is some duplication
- [x] Add in docstrings to the new methods
- [x] Make the code PEP8 compliant

I have found some edge cases where the above did not work properly. These all surround what happens when the cursor is on an error line. Most of this has been fixed in commit 1b75425 but one problem remains.

We need to know when the caret is at the end of a line. Currently if you are at the end of an error line and press return, the error highlighting will move down one line, when it should remain in place.

I have modified the code to contain logic to handle this, but have not been able to make a test for being at the end of a line yet, so this logic is currently set to `1 == 1`. Once I figure out this issue it will be a quick switch to add it in place of that logic.

### Update

The final commit (b3e1466) fixes the above issues by using the `old_text` instance variable to allow us to ID the line start and end positions before the most recent edit. This allows us to handle the cases where edits are happening on error lines.