### PR TITLE
Fixing file extension problems

### DIFF
--- a/python/nammu/controller/NammuController.py
+++ b/python/nammu/controller/NammuController.py
@@ -432,27 +432,37 @@ class NammuController(object):
         self.atfAreaController.clearToolTips()
 
         if self.currentFilename:
-            self.logger.debug("Validating ATF file %s.", self.currentFilename)
+            # Get the file extension of the current file
+            file_ext = os.path.splitext(self.currentFilename)[1]
 
-            # Search for project name in file. If not found, don't validate
-            project = self.get_project()
+            if file_ext == '.atf':
+                self.logger.debug("Validating ATF file %s.",
+                                  self.currentFilename)
 
-            if project:
-                self.send_command("atf", project)
-            else:
-                # TODO: Prompt dialog
-                if self.currentFilename:
-                    self.logger.error(
-                            "No project found in file %s. "
-                            "Add project and retry.",
-                            self.currentFilename)
+                # Search for project name in file. If not found, don't validate
+                project = self.get_project()
+
+                if project:
+                    self.send_command("atf", project)
                 else:
-                    self.logger.error(
-                            "No project found in file %s. "
-                            "Add project and retry.",
-                            self.currentFilename)
+                    # TODO: Prompt dialog
+                    if self.currentFilename:
+                        self.logger.error(
+                                "No project found in file %s. "
+                                "Add project and retry.",
+                                self.currentFilename)
+                    else:
+                        self.logger.error(
+                                "No project found in file %s. "
+                                "Add project and retry.",
+                                self.currentFilename)
 
-            self.logger.debug("Validating ATF done.")
+                self.logger.debug("Validating ATF done.")
+            else:
+                self.logger.error("Unable to validate file with extension {}. "
+                                  "Please re-save the file with the "
+                                  "file extension .atf and try "
+                                  "again.".format(file_ext))
         else:
             self.logger.error("Please save file before trying to validate.")
 

--- a/python/nammu/controller/NammuController.py
+++ b/python/nammu/controller/NammuController.py
@@ -206,6 +206,7 @@ class NammuController(object):
         Helper function to open file for reading.
         '''
         if os.path.splitext(filename)[1] != '.atf':
+            self.consoleController.clearConsole()
             self.logger.error("WARNING: supplied file ({}) does not appear "
                               "to be an atf file. File load may behave "
                               "unexpectedly.".format(filename))
@@ -263,6 +264,7 @@ class NammuController(object):
         Needed as non-atf files will not validate on the oracc server
         '''
         if os.path.splitext(filename)[1] != '.atf':
+            self.consoleController.clearConsole()
             self.logger.error("Supplied filename: {0} does not have the "
                               "required atf extension. File will be "
                               "saved as {0}.atf.".format(filename))

--- a/python/nammu/controller/NammuController.py
+++ b/python/nammu/controller/NammuController.py
@@ -219,6 +219,8 @@ class NammuController(object):
         atfText = self.atfAreaController.getAtfAreaText()
         if not self.currentFilename:
             fileChooser = JFileChooser(self.get_working_dir())
+            file_filter = FileNameExtensionFilter("ATF files", ["atf"])
+            fileChooser.setFileFilter(file_filter)
             status = fileChooser.showSaveDialog(self.view)
             if status == JFileChooser.APPROVE_OPTION:
                 atfFile = fileChooser.getSelectedFile()
@@ -236,6 +238,7 @@ class NammuController(object):
                             JOptionPane.YES_NO_OPTION)
                     if reply == JOptionPane.NO_OPTION:
                         return
+                filename = self.force_atf_extension(filename)
                 self.currentFilename = filename
                 self.view.setTitle(basename)
             else:
@@ -251,6 +254,19 @@ class NammuController(object):
 
         # Find project and language and add to settings.yaml as default
         self.update_config()
+
+    def force_atf_extension(self, filename):
+        '''
+        Ensures that any filename being saved has an atf extension.
+        Needed as non-atf files will not validate on the oracc server
+        '''
+        if os.path.splitext(filename)[1] != '.atf':
+            self.logger.error("Supplied filename: {0} does not have the "
+                              "required atf extension. File will be "
+                              "saved as {0}.atf.".format(filename))
+            filename = '{}.atf'.format(filename)
+
+        return filename
 
     def update_config(self):
         '''
@@ -286,6 +302,8 @@ class NammuController(object):
         '''
         atfText = self.atfAreaController.getAtfAreaText()
         fileChooser = JFileChooser(self.get_working_dir())
+        file_filter = FileNameExtensionFilter("ATF files", ["atf"])
+        fileChooser.setFileFilter(file_filter)
         status = fileChooser.showSaveDialog(self.view)
         if status == JFileChooser.APPROVE_OPTION:
             atfFile = fileChooser.getSelectedFile()
@@ -302,6 +320,7 @@ class NammuController(object):
                             JOptionPane.YES_NO_OPTION)
                 if reply == JOptionPane.NO_OPTION:
                     return
+            filename = self.force_atf_extension(filename)
             self.currentFilename = filename
             self.view.setTitle(basename)
             try:

--- a/python/nammu/controller/NammuController.py
+++ b/python/nammu/controller/NammuController.py
@@ -205,9 +205,12 @@ class NammuController(object):
         '''
         Helper function to open file for reading.
         '''
+        if os.path.splitext(filename)[1] != '.atf':
+            self.logger.error("WARNING: supplied file ({}) does not appear "
+                              "to be an atf file. File load may behave "
+                              "unexpectedly.".format(filename))
         text = codecs.open(filename, encoding='utf-8').read()
         return text
-        # TODO: Check if selected file is ATF or at least text file!
 
     def saveFile(self, event=None):
         '''

--- a/python/nammu/controller/NammuController.py
+++ b/python/nammu/controller/NammuController.py
@@ -270,7 +270,12 @@ class NammuController(object):
                           element, value)
         if value:
             if self.config[group][element] != value:
-                self.config[group][element] = value
+                # We need to ensure that this value is written inside a list
+                # otherwise we get odd behaviour for some config files.
+                if group == 'projects' and element == 'default':
+                    self.config[group][element] = [value]
+                else:
+                    self.config[group][element] = value
                 self.logger.debug("Settings updated.")
                 save_yaml_config(self.config)
 

--- a/python/nammu/controller/NammuController.py
+++ b/python/nammu/controller/NammuController.py
@@ -228,7 +228,6 @@ class NammuController(object):
             if status == JFileChooser.APPROVE_OPTION:
                 atfFile = fileChooser.getSelectedFile()
                 filename = atfFile.getCanonicalPath()
-                basename = atfFile.getName()
                 # Make sure users check before lightly overwriting a file
                 # No need to ask if they choose to save on the file they are
                 # currently and knowingly editing.
@@ -243,7 +242,7 @@ class NammuController(object):
                         return
                 filename = self.force_atf_extension(filename)
                 self.currentFilename = filename
-                self.view.setTitle(basename)
+                self.view.setTitle(os.path.basename(filename))
             else:
                 return
         try:

--- a/python/nammu/utils/__init__.py
+++ b/python/nammu/utils/__init__.py
@@ -135,7 +135,18 @@ def get_yaml_config(yaml_filename):
         update_yaml_config(path_to_jar, yaml_path, path_to_config)
 
     # Load YAML config
-    return yaml.load(open(path_to_config, 'r'))
+    return fix_old_default_project_yaml(yaml.load(open(path_to_config, 'r')))
+
+
+def fix_old_default_project_yaml(yaml):
+    '''
+    Method to ensure compatability between old config files and verisons
+    of nammu > 0.8
+    '''
+    if 'projects' in yaml.keys():
+        if isinstance(yaml['projects']['default'], basestring):
+            yaml['projects']['default'] = [yaml['projects']['default']]
+    return yaml
 
 
 def different_versions(version1, version2):

--- a/python/nammu/view/NewAtfView.py
+++ b/python/nammu/view/NewAtfView.py
@@ -176,7 +176,7 @@ class NewAtfView(JDialog):
             Prepares list of projects and subprojects ordered with the default
             one first.
             '''
-            default_project = self.projects['default'].split('/')[0]
+            default_project = self.projects['default'][0].split('/')[0]
             if '/' in self.projects['default']:
                 default_subproject = self.projects['default'].split('/')[1]
             else:


### PR DESCRIPTION
This PR fixes two related bugs described in #278 and #279.

The changes made are:

- Fixing the new atf file button so that it does not crash if the default project value is stored in the config file as a string rather than a string within a list
- Warning the user that they are trying to validate a non `*.atf` file rather than sending it to the server where it erroneously is reported as a valid file regardless of errors
- Updating the save and save as dialogues to prompt for `*.atf` files to be saved rather than `all files`
- Created new method to force filenames to have an `*.atf` extension upon save or save as
- Added a new warning when a user tries to load a non-atf file. The file will still load, but the user is warned this could cause problems.

Last thing to do before review and merge:

- [x] Investigate why the title bar filename does not show the appended file extension