### PR TITLE
Fixing model view problem on trying to load multi fragment files.

### DIFF
--- a/python/nammu/controller/AtfAreaController.py
+++ b/python/nammu/controller/AtfAreaController.py
@@ -21,7 +21,6 @@ from javax.swing.undo import CannotUndoException, CannotRedoException
 from java.awt import Color
 
 from ..view.AtfAreaView import AtfAreaView
-from ..view.LineNumbersArea import LineNumbersArea
 from ..view.AtfEditArea import AtfEditArea
 from ..view.SyntaxHighlighter import SyntaxHighlighter
 import TextLineNumber

--- a/python/nammu/controller/ModelController.py
+++ b/python/nammu/controller/ModelController.py
@@ -24,6 +24,7 @@ from pyoracc.model.translation import Translation
 from pyoracc.model.ruling import Ruling
 from pyoracc.model.comment import Comment
 from pyoracc.model.line import Line
+from pyoracc.model.composite import Composite
 
 
 class ModelController(object):
@@ -52,8 +53,32 @@ class ModelController(object):
         # Get ATF object parsed from text displated in text area
         self.atf = parsedAtf
 
+        # Shorthand for calling the logger
+        self.logger = self.controller.logger
+
         # Go through parsed ATF object, serialize and pass elements to view
         atfText = parsedAtf.text
+
+        # Clear the console before printng any messages
+        self.controller.consoleController.clearConsole()
+
+        self.logger.info("The Model View is an experimental feature, use with "
+                         "caution!")
+
+        if isinstance(atfText, Composite):
+            self.logger.info("The current file {} contains multiple fragments "
+                             "and cannot be loaded into the model view. Please"
+                             " save the file as individual fragments and try "
+                             " again".format(self.controller.currentFilename))
+        else:
+            self.configure_model_view_single(atfText)
+
+    def configure_model_view_single(self, atfText):
+        '''
+        At present the model view can only cope with files which represent a
+        single fragment. This method has been moved out of init so we only
+        call it if a single fragment file is loaded.
+        '''
 
         # Add a new tab in the view per object in the text
         objectID = "&" + atfText.code + " = " + atfText.description

--- a/python/nammu/controller/ModelController.py
+++ b/python/nammu/controller/ModelController.py
@@ -57,7 +57,10 @@ class ModelController(object):
         self.logger = self.controller.logger
 
         # Go through parsed ATF object, serialize and pass elements to view
-        atfText = parsedAtf.text
+        try:
+            atfText = parsedAtf.text
+        except:
+            atfText = None
 
         # Clear the console before printng any messages
         self.controller.consoleController.clearConsole()
@@ -65,11 +68,14 @@ class ModelController(object):
         self.logger.info("The Model View is an experimental feature, use with "
                          "caution!")
 
-        if isinstance(atfText, Composite):
+        if isinstance(atfText, Composite) and atfText:
             self.logger.info("The current file {} contains multiple fragments "
                              "and cannot be loaded into the model view. Please"
                              " save the file as individual fragments and try "
                              " again".format(self.controller.currentFilename))
+        elif atfText is None:
+            self.logger.info("The current file is formatted in a way that"
+                             "the model view cannot understand.")
         else:
             self.configure_model_view_single(atfText)
 

--- a/python/nammu/controller/NammuController.py
+++ b/python/nammu/controller/NammuController.py
@@ -174,7 +174,8 @@ class NammuController(object):
                 syntax_highlight.syntax_highlight_on = False
                 self.atfAreaController.setAtfAreaText(atfText)
 
-                self.logger.debug("File %s successfully opened.", filename)
+                self.consoleController.clearConsole()
+                self.logger.info("File %s successfully opened.", filename)
                 self.view.setTitle(basename)
 
                 # Re-enable caret updating and syntax highlighting after load


### PR DESCRIPTION
This resolves issue #282 by identifying when a must-fragment file has been loaded and warning the user to re save as separate single fragment files if they want to use the feature.

As this feature is experimental and incomplete at present a general warning to that effect has also been added to the console.

To better improve the flow of messages onto the console, the file loaded successfully message has been moved from a `debug` message to an `info` message and the console is refreshed upon new file load, so that these warnings do not persist after the user has resolved them by loading a new single fragment file.