### PR TITLE
Fixing the line height bug

### DIFF
--- a/python/nammu/controller/NammuController.py
+++ b/python/nammu/controller/NammuController.py
@@ -192,6 +192,9 @@ class NammuController(object):
             self.update_config_element(self.get_working_dir(),
                                        'default', 'working_dir')
 
+            # Finally, refresh the edit area to propagate custom font settings
+            self.atfAreaController.refreshEditArea()
+
     def initHighlighting(self):
         '''
         A helper function to be called when we need to initialise syntax

--- a/python/nammu/view/EditSettingsView.py
+++ b/python/nammu/view/EditSettingsView.py
@@ -20,6 +20,8 @@ along with Nammu.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
 import os
+from swingutils.threads.swing import runSwingLater
+
 from java.awt import GridLayout, Component, FlowLayout, Color, BorderLayout
 from java.awt import GridBagLayout, GridBagConstraints, Insets
 from javax.swing import JDialog, JFrame, JTabbedPane, JComponent, JPanel
@@ -474,6 +476,10 @@ class EditSettingsView(JDialog):
         self.controller.refreshEditArea()
         # Close window
         self.dispose()
+
+        # Refresh the syntax highlighting in a separate thread so it updates
+        # after everything else has been done.
+        runSwingLater(self.controller.controller.initHighlighting)
 
     def browse(self, event=None):
         '''


### PR DESCRIPTION
The bug was caused by the syntax highlight method not being called after file load on files with no vertical scroll bars. This has been fixed by adding a call to the initialise syntax highlighting method in a `runlater` thread using swingutils and adding another call to refresh the  edit area styling following new file load.

This resolves issue #285.