### PR TITLE
Changed error message to match validate_fontsize logic

### DIFF
--- a/python/nammu/view/EditSettingsView.py
+++ b/python/nammu/view/EditSettingsView.py
@@ -372,7 +372,7 @@ class EditSettingsView(JDialog):
         else:
             input_size = self.controller.config[target_key]['fontsize']['user']
             self.logger.error("Invalid {} font size. Please enter a "
-                              "number between 8 and 36.\n\n"
+                              "number between 8 and 30.\n\n"
                               "Font size left at "
                               "previous value: {}".format(target, input_size))
 


### PR DESCRIPTION
Just noticed this bug while I was trying to increase the font-size greater than 30.