### PR TITLE
Fix path handling when loading

### DIFF
--- a/python/nammu/utils/__init__.py
+++ b/python/nammu/utils/__init__.py
@@ -319,21 +319,18 @@ def copy_yaml_to_home(jar_file_path, source_rel_path, target_path):
     it to ~/.nammu.
     '''
     try:
-        zf = zipfile.ZipFile(jar_file_path, 'r')
+        with zipfile.ZipFile(jar_file_path, 'r') as zf:
+            lst = zf.infolist()
+            for zi in lst:
+                fn = zi.filename
+                if fn.lower() == source_rel_path:
+                    source_file = zf.open(fn)
+                    target_file = file(target_path, "wb")
+                    with source_file, target_file:
+                        shutil.copyfileobj(source_file, target_file)
     except zipfile.BadZipfile:
         shutil.copyfileobj(file(source_rel_path, "wb"),
                            file(target_path, "wb"))
-    else:
-        lst = zf.infolist()
-        for zi in lst:
-            fn = zi.filename
-            if fn.lower() == source_rel_path:
-                source_file = zf.open(fn)
-                target_file = file(target_path, "wb")
-                with source_file, target_file:
-                    shutil.copyfileobj(source_file, target_file)
-    finally:
-        zf.close()
 
 
 def find_image_resource(name):

--- a/python/nammu/utils/__init__.py
+++ b/python/nammu/utils/__init__.py
@@ -24,6 +24,7 @@ import collections
 import yaml
 import logging
 import re
+import urllib
 from java.lang import ClassLoader, System
 from java.io import InputStreamReader, BufferedReader
 from java.awt import Font
@@ -122,7 +123,12 @@ def get_yaml_config(yaml_filename):
     # In Unix getResource returns the path with prefix "file:" but in
     # Windows prefix is "jar:file:"
     path_to_jar = str(config_file_url).split('file:')[1]
-    path_to_jar = path_to_jar.split('!')[0]
+    # The path will be of the form /path/to/jar!path/inside/jar
+    # Take everything up to the final !, in case previous parts also contain !
+    path_to_jar = path_to_jar.rsplit('!', 1)[0]
+    # Decode any special characters contained in the path so that, for example,
+    # we use 'dir name' instead of 'dir%20name'
+    path_to_jar = urllib.unquote(path_to_jar)
 
     path_to_config = get_log_path(yaml_filename)
 

--- a/python/nammu/utils/__init__.py
+++ b/python/nammu/utils/__init__.py
@@ -128,6 +128,10 @@ def get_yaml_config(yaml_filename):
     path_to_jar = path_to_jar.rsplit('!', 1)[0]
     # Decode any special characters contained in the path so that, for example,
     # we use 'dir name' instead of 'dir%20name'
+    # NB: The standard way to do it is to create a URI from the URL, which will
+    # automatically handle the encoding, and then go back to a URL or String.
+    # However, the URI class doesn't seem to handle the jar:file: prefix well,
+    # so using urllib directly seems a better solution.
     path_to_jar = urllib.unquote(path_to_jar)
 
     path_to_config = get_log_path(yaml_filename)

--- a/python/nammu/utils/__init__.py
+++ b/python/nammu/utils/__init__.py
@@ -320,8 +320,7 @@ def copy_yaml_to_home(jar_file_path, source_rel_path, target_path):
     '''
     try:
         with zipfile.ZipFile(jar_file_path, 'r') as zf:
-            lst = zf.infolist()
-            for zi in lst:
+            for zi in zf.infolist():
                 fn = zi.filename
                 if fn.lower() == source_rel_path:
                     source_file = zf.open(fn)


### PR DESCRIPTION
Fixes #299. There were two issues:
- Paths containing spaces were encoded and not recognised when opening files there.
- When the above caused an error, there was a small bug in the error handling.

This should fix both of these, and also cover the corner case of a path containing an exclamation point, in which case the previous version would also fail (see [the issue comments](https://github.com/oracc/nammu/issues/299#issuecomment-341537955) for more details).