### PR TITLE
Fixing missing error messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 
 language: java
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: true
+sudo: false
 
 language: java
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ install:
        pip install --user pep8
     fi
 
+before_script:
+  - pip -V
+
 script:
   - |
     # Check if this is the PEP8 test instance and run pep8

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
 			<plugin>
 				<groupId>net.sf.mavenjython</groupId>
 				<artifactId>jython-compile-maven-plugin</artifactId>
-                                <version>1.4</version>
+                                <version>2.0</version>
 				<executions>
 					<execution>
 						<id>before-tests</id>
@@ -150,10 +150,9 @@
 				</executions>
 				<configuration>
          <libraries>
-            <param>--index-url=https://pypi.python.org/simple/</param>
-            <param>requests&lt;2.12.0</param>
-            <param>setuptools-scm</param>
-            <param>pytest&lt;2.3.0</param>
+            <param>requests</param>
+            <param>pytest</param>
+						<param>pyyaml</param>
 						<param>mako</param>
             <param>ply</param>
 						<param>jython-swingutils</param>

--- a/pom.xml
+++ b/pom.xml
@@ -158,11 +158,11 @@
          <libraries>
             <param>requests</param>
             <param>pytest</param>
-						<param>pyyaml</param>
 						<param>mako</param>
             <param>ply</param>
 						<param>jython-swingutils</param>
 						<param>pyoracc</param>
+            <param>pyyaml==3.12</param>
 					</libraries>
 				</configuration>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -156,8 +156,21 @@
 				</executions>
 				<configuration>
          <libraries>
-            <param>requests</param>
-            <param>pytest</param>
+
+            <!--
+            pytest is pinned to 2.9.2 as newer versions require an updated version
+            of setuptools which is incompatible with jython
+
+            requests is pinned to 2.11.0 as newer versions require urllib3, which is
+            incompatible with jython
+
+            pyyaml is pinned to 3.12 as version 3.13's install fails for unknown
+            reasons. The pyyaml project is working on a new release for python 3.7,
+            so I anticipate more compatibility issues between pyyaml and jython in the
+            future --SWDG
+            -->
+            <param>requests==2.11.0</param>
+            <param>pytest==2.9.2</param>
 						<param>mako</param>
             <param>ply</param>
 						<param>jython-swingutils</param>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
 			<plugin>
 				<groupId>net.sf.mavenjython</groupId>
 				<artifactId>jython-compile-maven-plugin</artifactId>
-                                <version>1.4</version>
+                                <version>2.0</version>
 				<executions>
 					<execution>
 						<id>before-tests</id>
@@ -149,15 +149,14 @@
 					</execution>
 				</executions>
 				<configuration>
-                                        <libraries>
-                                                <param>--index-url=https://pypi.python.org/simple/</param>
-                                                <param>requests&lt;2.12.0</param>
-                                                <param>pytest&lt;3.0</param>
+         <libraries>
+            <param>requests</param>
+            <param>pytest</param>
 						<param>pyyaml</param>
 						<param>mako</param>
-						<param>ply</param>
+            <param>ply</param>
 						<param>jython-swingutils</param>
-						<param>https://github.com/ucl/pyoracc/archive/master.tar.gz</param>
+						<param>pyoracc</param>
 					</libraries>
 				</configuration>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -169,9 +169,10 @@
             so I anticipate more compatibility issues between pyyaml and jython in the
             future -SWDG
             -->
+            <param>--user</param>
             <param>requests==2.11.0</param>
             <param>pytest==2.9.2</param>
-					
+						<param>mako</param>
             <param>ply</param>
 						<param>jython-swingutils</param>
 						<param>pyoracc</param>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,8 @@
          <libraries>
             <param>--index-url=https://pypi.python.org/simple/</param>
             <param>requests&lt;2.12.0</param>
-            <param>pytest&lt;2.9.2</param>
+            <param>setuptools-scm</param>
+            <param>pytest&lt;2.3.0</param>
 						<param>mako</param>
             <param>ply</param>
 						<param>jython-swingutils</param>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,12 @@
 			<resource>
 				<directory>python</directory>
 			</resource>
+
+      <!-- Copy the site packages into the jar -->
+      <resource>
+        <directory>${basedir}/target/jython-plugins-tmp/Lib/site-packages</directory>
+        <targetPath>Lib/site-packages/</targetPath>
+      </resource>
 		</resources>
 
 		<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
             -->
             <param>requests==2.11.0</param>
             <param>pytest==2.9.2</param>
-						<param>mako</param>
+					
             <param>ply</param>
 						<param>jython-swingutils</param>
 						<param>pyoracc</param>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>uk.ac.ucl.rc.development.oracc</groupId>
 	<artifactId>nammu</artifactId>
-	<version>1.0.0</version>
+	<version>1.1.0</version>
 	<packaging>jar</packaging>
 
 	<name>nammu</name>

--- a/pom.xml
+++ b/pom.xml
@@ -150,9 +150,9 @@
 				</executions>
 				<configuration>
          <libraries>
-            <param>requests</param>
-            <param>pytest</param>
-						<param>pyyaml</param>
+            <param>--index-url=https://pypi.python.org/simple/</param>
+            <param>requests&lt;2.12.0</param>
+            <param>pytest&lt;3.0</param>
 						<param>mako</param>
             <param>ply</param>
 						<param>jython-swingutils</param>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
          <libraries>
             <param>--index-url=https://pypi.python.org/simple/</param>
             <param>requests&lt;2.12.0</param>
-            <param>pytest&lt;3.0</param>
+            <param>pytest&lt;2.9.2</param>
 						<param>mako</param>
             <param>ply</param>
 						<param>jython-swingutils</param>

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
             pyyaml is pinned to 3.12 as version 3.13's install fails for unknown
             reasons. The pyyaml project is working on a new release for python 3.7,
             so I anticipate more compatibility issues between pyyaml and jython in the
-            future --SWDG
+            future -SWDG
             -->
             <param>requests==2.11.0</param>
             <param>pytest==2.9.2</param>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
 			<plugin>
 				<groupId>net.sf.mavenjython</groupId>
 				<artifactId>jython-compile-maven-plugin</artifactId>
-                                <version>2.0</version>
+                                <version>1.4</version>
 				<executions>
 					<execution>
 						<id>before-tests</id>

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,6 @@
             so I anticipate more compatibility issues between pyyaml and jython in the
             future -SWDG
             -->
-            <param>--user</param>
             <param>requests==2.11.0</param>
             <param>pytest==2.9.2</param>
 						<param>mako</param>

--- a/python/nammu/controller/AtfAreaController.py
+++ b/python/nammu/controller/AtfAreaController.py
@@ -364,3 +364,24 @@ class AtfAreaController(object):
         Repaint edit area with appeareance chosen by user.
         '''
         self.view.refresh()
+
+    def findArabic(self, text):
+        '''
+        Returns the caret position of the beginning of the arabic block, if one
+        is found. Otherwise returns None.
+
+        Add additional values to lang_codes or trans_types if we need to
+        support other translation styles or right to left langages in the
+        future
+        '''
+        lang_codes = '|'.join(['ar', 'fa', 'ku'])
+        trans_types = '|'.join(['parallel', 'labeled', 'unitary'])
+
+        regex = r'@translation(\s({}))(\s({})\s)(.*\n)+?'.format(trans_types,
+                                                                 lang_codes)
+        comp = re.compile(regex)
+        search = comp.search(text, re.MULTILINE)
+        if search:
+            return search.end()
+        else:
+            return None

--- a/python/nammu/controller/NammuController.py
+++ b/python/nammu/controller/NammuController.py
@@ -44,7 +44,7 @@ from javax.swing import JFileChooser, JOptionPane, ToolTipManager, JSplitPane
 from javax.swing.filechooser import FileNameExtensionFilter
 from javax.swing.text import DefaultCaret
 from pyoracc.atf.common.atffile import AtfFile
-from requests.exceptions import RequestException
+from requests.exceptions import RequestException, ConnectTimeout
 from requests.exceptions import Timeout, ConnectionError, HTTPError
 
 from ..SOAPClient.SOAPClient import SOAPClient

--- a/python/nammu/controller/NammuController.py
+++ b/python/nammu/controller/NammuController.py
@@ -657,7 +657,8 @@ class NammuController(object):
                               client.url)
             self.logger.error('You can try with a different server from the '
                               'settings menu.')
-            raise Exception('Connetion to server %s timed out.', url)
+            raise Exception('Connection to server {} timed '
+                            'out.'.format(client.url))
         except ConnectionError:
             raise Exception("Can't connect to ORACC server at %s.",
                             client.url)

--- a/python/nammu/main.py
+++ b/python/nammu/main.py
@@ -17,6 +17,14 @@ You should have received a copy of the GNU General Public License
 along with Nammu.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
+# http://bugs.jython.org/issue2143
+import site
+from org.python.util import jython
+jar_location = jython().getClass().getProtectionDomain().getCodeSource().getLocation().getPath()
+import site
+import os.path
+site.addsitedir(os.path.join(jar_location, 'Lib/site-packages'))
+
 from controller.NammuController import NammuController
 
 

--- a/python/nammu/view/SyntaxHighlighter.py
+++ b/python/nammu/view/SyntaxHighlighter.py
@@ -225,6 +225,30 @@ class SyntaxHighlighter:
                                                      mylength,
                                                      attribs,
                                                      True)
+        # Deal with multi-language translations
+        self.justify_translation(text)
+
+    def justify_translation(self, text):
+        '''
+        Method to justify parallel translations dependant on if they are
+        Arabic or not.
+        '''
+
+        atfCont = self.controller.controller.atfAreaController
+        arabicIndex = atfCont.findArabic(text)
+
+        justify = SimpleAttributeSet()
+
+        if arabicIndex:
+            StyleConstants.setAlignment(justify, StyleConstants.ALIGN_RIGHT)
+            self.styledoc.setParagraphAttributes(arabicIndex,
+                                                 self.styledoc.getLength() + 1,
+                                                 justify, True)
+        else:
+            StyleConstants.setAlignment(justify, StyleConstants.ALIGN_LEFT)
+            self.styledoc.setParagraphAttributes(0,
+                                                 self.styledoc.getLength() + 1,
+                                                 justify, True)
 
     def highlight_matches(self, matches, offset=0, current_match=None):
         '''

--- a/src/test/java/uk/ac/ucl/rc/development/oracc/nammu/NammuTest.java
+++ b/src/test/java/uk/ac/ucl/rc/development/oracc/nammu/NammuTest.java
@@ -1,21 +1,21 @@
 /**
  * Copyright 2015 - 2017 University College London.
- * 
+ *
  * This file is part of Nammu.
  *
  * Nammu is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Nammu is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with Nammu.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  */
 
 package uk.ac.ucl.rc.development.oracc.nammu;
@@ -43,6 +43,12 @@ public class NammuTest {
       systemState.path.append(new PyString("target/jython-plugins-tmp/build/pytest"));
       systemState.path.append(new PyString("target/jython-plugins-tmp/build/py"));
       systemState.path.append(new PyString("target/jython-plugins-tmp/build/requests"));
+      systemState.path.append(new PyString("target/jython-plugins-tmp/build/six"));
+      systemState.path.append(new PyString("target/jython-plugins-tmp/build/attrs"));
+      systemState.path.append(new PyString("target/jython-plugins-tmp/build/funcsigs"));
+      systemState.path.append(new PyString("target/jython-plugins-tmp/build/pluggy"));
+      systemState.path.append(new PyString("target/jython-plugins-tmp/build/atomicwrites"));
+      systemState.path.append(new PyString("target/jython-plugins-tmp/build/more-itertools"));
       PythonInterpreter interpreter = new PythonInterpreter();
       systemState.__setattr__("_jy_interpreter", Py.java2py(interpreter));
       String command = "try:\n "


### PR DESCRIPTION
As reported in #317 server timeout messages were not being propagated to the user. This pr resolves that by importing a missing exception and fixing another exception which was being passed as a tuple instead of a string.

Users will now see an appropriate error message if the server times out:

![screen shot 2018-05-24 at 15 00 48](https://user-images.githubusercontent.com/10617231/40490527-a403fc5e-5f63-11e8-923c-f0908f11b031.png)
