### PR TITLE
Various YAML updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ parsetab.py
 **/effective-pom*.xml
 *.atf
 resources/lib
+.vagrant/

--- a/python/nammu/test/test_yaml_update.py
+++ b/python/nammu/test/test_yaml_update.py
@@ -23,7 +23,7 @@ import os
 import yaml
 
 from python.nammu.controller.NammuController import NammuController
-from ..utils import update_yaml_config
+from ..utils import get_home_env_var, update_yaml_config
 
 
 def test_update_yaml_config():
@@ -52,14 +52,13 @@ def test_settings_copied_correctly(monkeypatch, tmpdir):
     More specifically, this test ensures that, if the user starts Nammu without
     already having any configuration files, then local configuration files with
     the correct content will be created, without affecting the original files.
-
-    This test currently assumes it will run on Linux/Mac.
     """
     # Mock the user's home directory
-    monkeypatch.setitem(os.environ, 'HOME', str(tmpdir))
+    home_env_var = get_home_env_var()  # will vary depending on OS
+    monkeypatch.setitem(os.environ, home_env_var, str(tmpdir))
     assert os.listdir(str(tmpdir)) == []  # sanity check!
     NammuController()  # start up Nammu, but don't do anything with it
-    settings_dir = os.path.join(os.environ['HOME'], '.nammu')
+    settings_dir = os.path.join(os.environ[home_env_var], '.nammu')
     for filename in ['settings.yaml', 'logging.yaml']:
         target_file = os.path.join(settings_dir, filename)
         original_file = os.path.join('resources', 'config', filename)

--- a/python/nammu/test/test_yaml_update.py
+++ b/python/nammu/test/test_yaml_update.py
@@ -20,25 +20,29 @@ along with Nammu.  If not, see <http://www.gnu.org/licenses/>.
 import filecmp
 import os
 
-import pytest
+import yaml
 
 from python.nammu.controller.NammuController import NammuController
-# from ..utils import update_yaml_config
+from ..utils import update_yaml_config
 
 
-@pytest.mark.skip(reason=("pyyaml is not working in the tests yet"))
 def test_update_yaml_config():
     """
-    Ensure that upon updating yaml settings files from jar, a users
+    Ensure that, upon updating yaml settings files from jar, a user's
     default project settings are not overwritten.
     """
     pth = "resources/test/"
-    d = update_yaml_config(path_to_jar=pth+"jar_settings.yaml",
-                           yaml_path=pth+"user_settings.yaml",
-                           path_to_config=pth+"user_settings.yaml",
-                           test_mode=True)
-    # assert goal_setting == jar_config
-    # make sure the user (project) setting is not overwritten....
+    local_file = os.path.join(pth, "user_settings.yaml")
+    jar_file = os.path.join(pth, "jar_settings.yaml")
+    new_config = update_yaml_config(path_to_jar=jar_file,
+                                    yaml_path=local_file,
+                                    path_to_config=local_file,
+                                    test_mode=True)
+    with open(local_file, "r") as f:
+        orig_config = yaml.safe_load(f)
+    # Make sure the user (project) setting is not overwritten
+    assert (new_config["projects"]["default"]
+            == orig_config["projects"]["default"])
 
 
 def test_settings_copied_correctly(monkeypatch, tmpdir):

--- a/python/nammu/test/test_yaml_update.py
+++ b/python/nammu/test/test_yaml_update.py
@@ -41,8 +41,8 @@ def test_update_yaml_config():
     with open(local_file, "r") as f:
         orig_config = yaml.safe_load(f)
     # Make sure the user (project) setting is not overwritten
-    assert (new_config["projects"]["default"]
-            == orig_config["projects"]["default"])
+    assert (new_config["projects"]["default"] ==
+            orig_config["projects"]["default"])
 
 
 def test_settings_copied_correctly(monkeypatch, tmpdir):

--- a/python/nammu/test/test_yaml_update.py
+++ b/python/nammu/test/test_yaml_update.py
@@ -62,7 +62,7 @@ def test_settings_copied_correctly(monkeypatch, tmpdir):
     settings_dir = os.path.join(os.environ['HOME'], '.nammu')
     for filename in ['settings.yaml', 'logging.yaml']:
         target_file = os.path.join(settings_dir, filename)
-        original_file = os.path.join('resources/config', filename)
+        original_file = os.path.join('resources', 'config', filename)
         assert os.path.isfile(target_file)
         assert filecmp.cmp(target_file, original_file)
         # Check that the original config files have not been emptied (see #347)

--- a/python/nammu/utils/__init__.py
+++ b/python/nammu/utils/__init__.py
@@ -140,7 +140,6 @@ def get_yaml_config(yaml_filename):
     if not os.path.isfile(path_to_config):
         copy_yaml_to_home(path_to_jar, yaml_path, path_to_config)
     else:
-        # We are running from the JAR file, not the local console
         update_yaml_config(path_to_jar, yaml_path, path_to_config)
 
     # Load local YAML file and perform required patches on the settings in

--- a/python/nammu/utils/__init__.py
+++ b/python/nammu/utils/__init__.py
@@ -330,8 +330,8 @@ def copy_yaml_to_home(jar_file_path, source_rel_path, target_path):
                     with source_file, target_file:
                         shutil.copyfileobj(source_file, target_file)
     except zipfile.BadZipfile:
-        shutil.copyfileobj(file(source_rel_path, "wb"),
-                           file(target_path, "wb"))
+        with open(source_rel_path, "r") as src, open(target_path, "w") as dest:
+            shutil.copyfileobj(src, dest)
 
 
 def find_image_resource(name):

--- a/python/nammu/utils/__init__.py
+++ b/python/nammu/utils/__init__.py
@@ -297,17 +297,23 @@ def update_yaml_config(path_to_jar, yaml_path, path_to_config, verbose=False,
             # Need to apply the patching to correct any problems between
             # version 0.8 and version 1.0
             d = patch_config(d)
-            save_yaml_config(d)
+            save_yaml_config(d, filename=os.path.basename(path_to_config))
     else:
         return
 
 
-def save_yaml_config(config):
+def save_yaml_config(config, filename='settings.yaml'):
     '''
     Overwrites settings with given config dict.
+
+    If a file name (e.g. "logging.yaml") is expliclity specified, then that
+    configuration file will be overwritten; otherwise, overwrites the settings
+    file by default.
+    Note that this function can also be called during Nammu's lifetime
+    (e.g. when a file is saved), not only during launch.
     '''
     # Get config path
-    path_to_config = get_log_path('settings.yaml')
+    path_to_config = get_log_path(filename)
 
     # Save given config in yaml file
     with open(path_to_config, 'w') as outfile:

--- a/python/nammu/utils/__init__.py
+++ b/python/nammu/utils/__init__.py
@@ -227,11 +227,11 @@ def get_config_versions(path_to_jar, yaml_path, path_to_config):
     try:
         jar_contents = zipfile.ZipFile(path_to_jar, 'r')
     except zipfile.BadZipfile:
-        jar_config = yaml.load(open(path_to_jar, 'r'))
+        jar_config = yaml.safe_load(open(path_to_jar, 'r'))
     else:
-        jar_config = yaml.load(jar_contents.open(yaml_path))
+        jar_config = yaml.safe_load(jar_contents.open(yaml_path))
 
-    local_config = yaml.load(open(path_to_config, 'r'))
+    local_config = yaml.safe_load(open(path_to_config, 'r'))
     jar_version = str(jar_config['version'])
     local_version = str(local_config['version'])
 


### PR DESCRIPTION
Includes:
- Addressing recent warning for PyYAML safety (fixes #369)
- Fixing the error of accidentally erasing the config files when running from source, when a local configuration did not exist (fixes #347)
- Various small fixes and improvements to the configuration loading

Still to do:
- [x] Test line endings work well on Windows (when running from the jar), after changing from binary to text mode
- [ ] Remove the double version-checking and patching, assuming it is not necessary (now in #403)
- [x] Add a test to check that we don't overwrite the user's exusting configuration
- [ ] Double check that we do not update the local configuration files somewhere else (#344) - nothing found so far
- [ ] Display a message box if the settings file is corrupt, and log it (#345)