### PR TITLE
Directly set the font of edit areas in AtfAreaView.refresh()

### DIFF
--- a/python/nammu/controller/AtfAreaController.py
+++ b/python/nammu/controller/AtfAreaController.py
@@ -70,8 +70,9 @@ class AtfAreaController(object):
         # Setting the edit area here as well forces both line numbers to be
         # the same size
         self.conf = self.controller.config
-        font = set_font(self.conf['edit_area_style']['fontsize']['user'])
+        font = set_font(self.conf['arabic_pane_style']['fontsize']['user'])
         self.arabic_area.setFont(font)
+        font = set_font(self.conf['edit_area_style']['fontsize']['user'])
         self.edit_area.setFont(font)
         self.secondary_area.setFont(font)
 

--- a/python/nammu/controller/AtfAreaController.py
+++ b/python/nammu/controller/AtfAreaController.py
@@ -70,7 +70,7 @@ class AtfAreaController(object):
         # Setting the edit area here as well forces both line numbers to be
         # the same size
         self.conf = self.controller.config
-        font = set_font(self.conf['arabic_pane_style']['fontsize']['user'])
+        font = set_font(self.conf['arabic_area_style']['fontsize']['user'])
         self.arabic_area.setFont(font)
         font = set_font(self.conf['edit_area_style']['fontsize']['user'])
         self.edit_area.setFont(font)

--- a/python/nammu/controller/EditSettingsController.py
+++ b/python/nammu/controller/EditSettingsController.py
@@ -39,7 +39,7 @@ class EditSettingsController:
         '''
         config_keywords = ['working_dir', 'servers', 'keystrokes',
                            'languages', 'projects', 'console_style',
-                           'edit_area_style']
+                           'edit_area_style', 'arabic_pane_style']
         for keyword in config_keywords:
             try:
                 setattr(self, keyword, self.config[keyword])

--- a/python/nammu/controller/EditSettingsController.py
+++ b/python/nammu/controller/EditSettingsController.py
@@ -28,7 +28,7 @@ class EditSettingsController:
         self.load_config()
         self.view = EditSettingsView(self, self.working_dir, self.servers,
                                      self.console_style, self.edit_area_style,
-                                     self.arabic_pane_style, self.keystrokes,
+                                     self.arabic_area_style, self.keystrokes,
                                      self.languages, self.projects)
         self.view.display()
 
@@ -39,7 +39,7 @@ class EditSettingsController:
         '''
         config_keywords = ['working_dir', 'servers', 'keystrokes',
                            'languages', 'projects', 'console_style',
-                           'edit_area_style', 'arabic_pane_style']
+                           'edit_area_style', 'arabic_area_style']
         for keyword in config_keywords:
             try:
                 setattr(self, keyword, self.config[keyword])
@@ -50,7 +50,7 @@ class EditSettingsController:
 
     def update_config(self, working_dir, server, console_fontsize, font_color,
                       background_color, edit_area_fontsize,
-                      arabic_pane_fontsize, keystrokes=None, languages=None,
+                      arabic_area_fontsize, keystrokes=None, languages=None,
                       projects=None):
         '''
         Update the settings file with the user input.
@@ -65,8 +65,8 @@ class EditSettingsController:
         self.config[
                 'console_style']['background_color']['user'] = background_color
         self.config['edit_area_style']['fontsize']['user'] = edit_area_fontsize
-        self.config['arabic_pane_style']['fontsize'][
-            'user'] = arabic_pane_fontsize
+        self.config['arabic_area_style']['fontsize'][
+            'user'] = arabic_area_fontsize
         self.controller.logger.debug("Settings updated.")
         save_yaml_config(self.config)
 

--- a/python/nammu/controller/EditSettingsController.py
+++ b/python/nammu/controller/EditSettingsController.py
@@ -28,8 +28,8 @@ class EditSettingsController:
         self.load_config()
         self.view = EditSettingsView(self, self.working_dir, self.servers,
                                      self.console_style, self.edit_area_style,
-                                     self.keystrokes, self.languages,
-                                     self.projects)
+                                     self.arabic_pane_style, self.keystrokes,
+                                     self.languages, self.projects)
         self.view.display()
 
     def load_config(self):
@@ -49,8 +49,9 @@ class EditSettingsController:
                 self.view.display_error(keyword)
 
     def update_config(self, working_dir, server, console_fontsize, font_color,
-                      background_color, edit_area_fontsize, keystrokes=None,
-                      languages=None, projects=None):
+                      background_color, edit_area_fontsize,
+                      arabic_pane_fontsize, keystrokes=None, languages=None,
+                      projects=None):
         '''
         Update the settings file with the user input.
         '''
@@ -64,6 +65,8 @@ class EditSettingsController:
         self.config[
                 'console_style']['background_color']['user'] = background_color
         self.config['edit_area_style']['fontsize']['user'] = edit_area_fontsize
+        self.config['arabic_pane_style']['fontsize'][
+            'user'] = arabic_pane_fontsize
         self.controller.logger.debug("Settings updated.")
         save_yaml_config(self.config)
 

--- a/python/nammu/view/AtfAreaView.py
+++ b/python/nammu/view/AtfAreaView.py
@@ -250,10 +250,13 @@ class AtfAreaView(JPanel):
         doc.setCharacterAttributes(0, doc.getLength() + 1, attrs, False)
 
         # Also apply new fontsize to arabic pane
+        arabic_attrs = self.controller.arabic_area.getInputAttributes()
+        arabic_font = set_font(config['arabic_pane_style']['fontsize']['user'])
         arabic_doc = self.controller.arabic_area.getStyledDocument()
+        StyleConstants.setFontSize(arabic_attrs, arabic_font.getSize())
         arabic_doc.setCharacterAttributes(0,
                                           arabic_doc.getLength() + 1,
-                                          attrs,
+                                          arabic_attrs,
                                           False)
 
 

--- a/python/nammu/view/AtfAreaView.py
+++ b/python/nammu/view/AtfAreaView.py
@@ -248,6 +248,7 @@ class AtfAreaView(JPanel):
             doc = area.getStyledDocument()
             # Apply the new fontsize to the whole document
             doc.setCharacterAttributes(0, doc.getLength() + 1, attrs, False)
+            area.setFont(font)
 
 
 class atfAreaDocumentListener(DocumentListener):

--- a/python/nammu/view/AtfAreaView.py
+++ b/python/nammu/view/AtfAreaView.py
@@ -232,32 +232,22 @@ class AtfAreaView(JPanel):
 
         config = self.controller.controller.config
 
-        # Create a new font with the new size
-        font = set_font(config['edit_area_style']['fontsize']['user'])
-
-        # Update the sytnax highlighter font params, so our changes are not
-        # superceded
-        self.controller.syntax_highlighter.font = font
-        self.controller.syntax_highlighter.setup_attribs()
-
-        attrs = self.controller.edit_area.getInputAttributes()
-        StyleConstants.setFontSize(attrs, font.getSize())
-
-        # Get the Styledoc so we can update it
-        doc = self.controller.edit_area.getStyledDocument()
-
-        # Apply the new fontsize to the whole document
-        doc.setCharacterAttributes(0, doc.getLength() + 1, attrs, False)
-
-        # Also apply new fontsize to arabic pane
-        arabic_attrs = self.controller.arabic_area.getInputAttributes()
-        arabic_font = set_font(config['arabic_pane_style']['fontsize']['user'])
-        arabic_doc = self.controller.arabic_area.getStyledDocument()
-        StyleConstants.setFontSize(arabic_attrs, arabic_font.getSize())
-        arabic_doc.setCharacterAttributes(0,
-                                          arabic_doc.getLength() + 1,
-                                          arabic_attrs,
-                                          False)
+        for area_name in ['edit', 'arabic']:
+            area = getattr(self.controller, "{}_area".format(area_name))
+            style = "{}_area_style".format(area_name)
+            # Create a new font with the new size
+            font = set_font(config[style]['fontsize']['user'])
+            if area_name == 'edit':
+                # Update the sytnax highlighter font params, so our changes are
+                # not superceded
+                self.controller.syntax_highlighter.font = font
+                self.controller.syntax_highlighter.setup_attribs()
+            attrs = area.getInputAttributes()
+            StyleConstants.setFontSize(attrs, font.getSize())
+            # Get the Styledoc so we can update it
+            doc = area.getStyledDocument()
+            # Apply the new fontsize to the whole document
+            doc.setCharacterAttributes(0, doc.getLength() + 1, attrs, False)
 
 
 class atfAreaDocumentListener(DocumentListener):

--- a/python/nammu/view/EditSettingsView.py
+++ b/python/nammu/view/EditSettingsView.py
@@ -151,123 +151,100 @@ class EditSettingsView(JDialog):
 
     def build_console_background_color_panel(self, constraints, panel):
         '''
-        Server location row: label + dropdown
-        Contains a drop down with the servers to choose from.
+        Console background color: label + dropdown
         '''
-        console_bg_label = JLabel("Console background color:")
-        constraints = self.add_constraints(constraints, weightx=0.30,
-                                           gridx=0, gridy=3)
-        panel.add(console_bg_label, constraints)
-
         self.bg_color_combo = self.build_combobox(self.color_options,
                                                   self.console_bg_color)
-        constraints = self.add_constraints(constraints, weightx=0.70,
-                                           gridx=1, gridy=3, gridwidth=2,
-                                           fill=GridBagConstraints.HORIZONTAL)
-        panel.add(self.bg_color_combo, constraints)
+        self.build_drop_down_menu(constraints, panel, self.bg_color_combo,
+                                  JLabel("Console background color:"), 3)
 
     def build_console_font_color_panel(self, constraints, panel):
         '''
-        Server location row: label + dropdown
-        Contains a drop down with the servers to choose from.
+        Console font color: label + dropdown
         '''
-        console_font_label = JLabel("Console font color:")
-        constraints = self.add_constraints(constraints, weightx=0.30,
-                                           gridx=0, gridy=4)
-        panel.add(console_font_label, constraints)
-
         self.font_color_combo = self.build_combobox(self.color_options,
                                                     self.console_font_color)
+        self.build_drop_down_menu(constraints, panel, self.font_color_combo,
+                                  JLabel("Console font color:"), 4)
+
+    def build_drop_down_menu(self, constraints, panel, combo,
+                             label, gridy, insets=None):
+        '''
+        Create a drop down option for the panel.
+        '''
+        constraints = self.add_constraints(constraints, weightx=0.30,
+                                           gridx=0, gridy=gridy,
+                                           insets=insets)
+        panel.add(label, constraints)
+
         constraints = self.add_constraints(constraints, weightx=0.70,
-                                           gridx=1, gridy=4, gridwidth=2,
+                                           gridx=1, gridy=gridy, gridwidth=2,
                                            fill=GridBagConstraints.HORIZONTAL)
-        panel.add(self.font_color_combo, constraints)
+        panel.add(combo, constraints)
 
     def build_servers_panel(self, constraints, panel):
         '''
         Server location row: label + dropdown
         Contains a drop down with the servers to choose from.
         '''
-        server_label = JLabel("ORACC server location:")
-        constraints = self.add_constraints(constraints, weightx=0.30,
-                                           gridx=0, gridy=1,
-                                           insets=Insets(10, 10, 80, 10))
-        panel.add(server_label, constraints)
-
         self.combo = self.build_servers_combobox()
-        constraints = self.add_constraints(constraints, weightx=0.70,
-                                           gridx=1, gridy=1, gridwidth=2,
+        self.build_drop_down_menu(constraints, panel, self.combo,
+                                  JLabel("ORACC server location:"), 1,
+                                  Insets(10, 10, 80, 10))
+
+    def build_font_settings_panel(self, constraints, panel, label, gridy,
+                                  fs_field, fontsize, style):
+        '''
+        Font size on a textfield.
+        '''
+        constraints = self.add_constraints(constraints, weightx=0.20,
+                                           gridx=0, gridy=gridy,
                                            fill=GridBagConstraints.HORIZONTAL)
-        panel.add(self.combo, constraints)
+        panel.add(label, constraints)
+
+        fs_field.setEditable(True)
+        if fontsize:
+            fs_field.setText("{}".format(fontsize))
+        else:
+            fs_field.setText(self.controller.config[
+                style]['fontsize']['default'])
+
+        constraints = self.add_constraints(constraints, weightx=0.80,
+                                           gridx=1, gridy=gridy,
+                                           fill=GridBagConstraints.HORIZONTAL)
+        panel.add(fs_field, constraints)
 
     def build_console_font_panel(self, constraints, panel):
         '''
-        Font size on a textfield.
+        Font settings for consol pane.
         '''
-        fontzise_label = JLabel("Console font size:")
-        constraints = self.add_constraints(constraints, weightx=0.20,
-                                           gridx=0, gridy=2,
-                                           fill=GridBagConstraints.HORIZONTAL)
-        panel.add(fontzise_label, constraints)
-
         self.fs_field = JTextField()
-        self.fs_field.setEditable(True)
-        if self.console_fontsize:
-            self.fs_field.setText("{}".format(self.console_fontsize))
-        else:
-            self.fs_field.setText(self.controller.config[
-                                    'console_style']['fontsize']['default'])
-
-        constraints = self.add_constraints(constraints, weightx=0.80,
-                                           gridx=1, gridy=2,
-                                           fill=GridBagConstraints.HORIZONTAL)
-        panel.add(self.fs_field, constraints)
+        self.build_font_settings_panel(constraints, panel,
+                                       JLabel("Console font size:"), 2,
+                                       self.fs_field, self.console_fontsize,
+                                       'console_style')
 
     def build_edit_area_font_panel(self, constraints, panel):
         '''
-        Font size on a textfield.
+        Font settings for edit are pane.
         '''
-        fontzise_label = JLabel("Edit area font size:")
-        constraints = self.add_constraints(constraints, weightx=0.20,
-                                           gridx=0, gridy=0)
-        panel.add(fontzise_label, constraints)
-
         self.edit_area_fs_field = JTextField()
-        self.edit_area_fs_field.setEditable(True)
-        if self.edit_area_fontsize:
-            self.edit_area_fs_field.setText(
-                                    "{}".format(self.edit_area_fontsize))
-        else:
-            self.edit_area_fs_field.setText(self.controller.config[
-                                    'edit_area_style']['fontsize']['default'])
-
-        constraints = self.add_constraints(constraints, weightx=0.80,
-                                           gridx=1, gridy=0,
-                                           fill=GridBagConstraints.HORIZONTAL)
-        panel.add(self.edit_area_fs_field, constraints)
+        self.build_font_settings_panel(constraints, panel,
+                                       JLabel("Edit area font size:"), 0,
+                                       self.edit_area_fs_field,
+                                       self.edit_area_fontsize,
+                                       'edit_area_style')
 
     def build_arabic_pane_font_panel(self, constraints, panel):
         '''
-        Font size in Arabic pane's textfield.
+        Font settings in Arabic pane's textfield.
         '''
-        fontzise_label = JLabel("Arabic pane font size:")
-        constraints = self.add_constraints(constraints, weightx=0.20,
-                                           gridx=0, gridy=1)
-        panel.add(fontzise_label, constraints)
-
         self.arabic_pane_fs_field = JTextField()
-        self.arabic_pane_fs_field.setEditable(True)
-        if self.edit_area_fontsize:
-            self.arabic_pane_fs_field.setText(
-                "{}".format(self.edit_area_fontsize))
-        else:
-            self.arabic_pane_fs_field.setText(self.controller.config[
-                'arabic_pane_style']['fontsize']['default'])
-
-        constraints = self.add_constraints(constraints, weightx=0.80,
-                                           gridx=1, gridy=1,
-                                           fill=GridBagConstraints.HORIZONTAL)
-        panel.add(self.arabic_pane_fs_field, constraints)
+        self.build_font_settings_panel(constraints, panel,
+                                       JLabel("Arabic pane font size:"), 1,
+                                       self.arabic_pane_fs_field,
+                                       self.edit_area_fontsize,  # FIXME
+                                       'arabic_pane_style')
 
     def build_combobox(self, choices, default):
         '''

--- a/python/nammu/view/EditSettingsView.py
+++ b/python/nammu/view/EditSettingsView.py
@@ -156,13 +156,13 @@ class EditSettingsView(JDialog):
         '''
         console_bg_label = JLabel("Console background color:")
         constraints = self.add_constraints(constraints, weightx=0.30,
-                                           gridx=0, gridy=2)
+                                           gridx=0, gridy=3)
         panel.add(console_bg_label, constraints)
 
         self.bg_color_combo = self.build_combobox(self.color_options,
                                                   self.console_bg_color)
         constraints = self.add_constraints(constraints, weightx=0.70,
-                                           gridx=1, gridy=2, gridwidth=2,
+                                           gridx=1, gridy=3, gridwidth=2,
                                            fill=GridBagConstraints.HORIZONTAL)
         panel.add(self.bg_color_combo, constraints)
 
@@ -173,13 +173,13 @@ class EditSettingsView(JDialog):
         '''
         console_font_label = JLabel("Console font color:")
         constraints = self.add_constraints(constraints, weightx=0.30,
-                                           gridx=0, gridy=3)
+                                           gridx=0, gridy=4)
         panel.add(console_font_label, constraints)
 
         self.font_color_combo = self.build_combobox(self.color_options,
                                                     self.console_font_color)
         constraints = self.add_constraints(constraints, weightx=0.70,
-                                           gridx=1, gridy=3, gridwidth=2,
+                                           gridx=1, gridy=4, gridwidth=2,
                                            fill=GridBagConstraints.HORIZONTAL)
         panel.add(self.font_color_combo, constraints)
 
@@ -206,7 +206,7 @@ class EditSettingsView(JDialog):
         '''
         fontzise_label = JLabel("Console font size:")
         constraints = self.add_constraints(constraints, weightx=0.20,
-                                           gridx=0, gridy=0,
+                                           gridx=0, gridy=2,
                                            fill=GridBagConstraints.HORIZONTAL)
         panel.add(fontzise_label, constraints)
 
@@ -219,7 +219,7 @@ class EditSettingsView(JDialog):
                                     'console_style']['fontsize']['default'])
 
         constraints = self.add_constraints(constraints, weightx=0.80,
-                                           gridx=1, gridy=0,
+                                           gridx=1, gridy=2,
                                            fill=GridBagConstraints.HORIZONTAL)
         panel.add(self.fs_field, constraints)
 
@@ -229,7 +229,7 @@ class EditSettingsView(JDialog):
         '''
         fontzise_label = JLabel("Edit area font size:")
         constraints = self.add_constraints(constraints, weightx=0.20,
-                                           gridx=0, gridy=4)
+                                           gridx=0, gridy=0)
         panel.add(fontzise_label, constraints)
 
         self.edit_area_fs_field = JTextField()
@@ -242,7 +242,7 @@ class EditSettingsView(JDialog):
                                     'edit_area_style']['fontsize']['default'])
 
         constraints = self.add_constraints(constraints, weightx=0.80,
-                                           gridx=1, gridy=4,
+                                           gridx=1, gridy=0,
                                            fill=GridBagConstraints.HORIZONTAL)
         panel.add(self.edit_area_fs_field, constraints)
 

--- a/python/nammu/view/EditSettingsView.py
+++ b/python/nammu/view/EditSettingsView.py
@@ -31,7 +31,7 @@ from javax.swing import JFileChooser
 
 class EditSettingsView(JDialog):
     def __init__(self, controller, working_dir, servers, console_style,
-                 edit_area_style, arabic_pane_style, keystrokes,
+                 edit_area_style, arabic_area_style, keystrokes,
                  languages, projects):
         self.logger = logging.getLogger("NammuController")
         self.setAlwaysOnTop(True)
@@ -45,7 +45,7 @@ class EditSettingsView(JDialog):
         self.console_font_color = console_style['font_color']['user']
         self.console_bg_color = console_style['background_color']['user']
         self.edit_area_fontsize = edit_area_style['fontsize']['user']
-        self.arabic_pane_fontsize = arabic_pane_style['fontsize']['user']
+        self.arabic_area_fontsize = arabic_area_style['fontsize']['user']
         self.pane = self.getContentPane()
 
         # Grab the console color options from the console view
@@ -191,7 +191,7 @@ class EditSettingsView(JDialog):
         '''
         self.combo = self.build_servers_combobox()
         self.build_drop_down_menu(constraints, panel, self.combo,
-                                  JLabel("ORACC server location:"), 1,
+                                  JLabel("Oracc server location:"), 1,
                                   Insets(10, 10, 80, 10))
 
     def build_font_settings_panel(self, constraints, panel, label, gridy,
@@ -237,16 +237,16 @@ class EditSettingsView(JDialog):
                                        self.edit_area_fontsize,
                                        'edit_area_style')
 
-    def build_arabic_pane_font_panel(self, constraints, panel):
+    def build_arabic_area_font_panel(self, constraints, panel):
         '''
         Font settings in Arabic pane's textfield.
         '''
-        self.arabic_pane_fs_field = JTextField()
+        self.arabic_area_fs_field = JTextField()
         self.build_font_settings_panel(constraints, panel,
                                        JLabel("Arabic pane font size:"), 1,
-                                       self.arabic_pane_fs_field,
-                                       self.arabic_pane_fontsize,
-                                       'arabic_pane_style')
+                                       self.arabic_area_fs_field,
+                                       self.arabic_area_fontsize,
+                                       'arabic_area_style')
 
     def build_combobox(self, choices, default):
         '''
@@ -330,7 +330,7 @@ class EditSettingsView(JDialog):
         self.build_console_font_color_panel(constraints, panel)
         self.build_console_background_color_panel(constraints, panel)
         self.build_edit_area_font_panel(constraints, panel)
-        self.build_arabic_pane_font_panel(constraints, panel)
+        self.build_arabic_area_font_panel(constraints, panel)
         return panel
 
     def display(self):
@@ -412,7 +412,7 @@ class EditSettingsView(JDialog):
             return None, False
 
     def validate_all_inputs(self, working_dir, console_fontsize,
-                            edit_area_fontsize, arabic_pane_fontsize,
+                            edit_area_fontsize, arabic_area_fontsize,
                             bg_color, font_color):
         '''
         Wrapper around the input validation methods. Returns a tuple containing
@@ -436,8 +436,8 @@ class EditSettingsView(JDialog):
                                               'edit_area_style')
         validation_results.append(v)
 
-        arabic_size, v = self.validate_fontsize(arabic_pane_fontsize,
-                                                'arabic_pane_style')
+        arabic_size, v = self.validate_fontsize(arabic_area_fontsize,
+                                                'arabic_area_style')
         validation_results.append(v)
 
         # Validate input console colors
@@ -458,7 +458,7 @@ class EditSettingsView(JDialog):
         # Read the fontsize from the textfield
         console_fontsize = self.fs_field.getText()
         edit_area_fontsize = self.edit_area_fs_field.getText()
-        arabic_pane_fontsize = self.arabic_pane_fs_field.getText()
+        arabic_area_fontsize = self.arabic_area_fs_field.getText()
 
         # Get the user selected font and background colours
         bg_color = self.bg_color_combo.getSelectedItem()
@@ -466,7 +466,7 @@ class EditSettingsView(JDialog):
 
         validated = self.validate_all_inputs(working_dir, console_fontsize,
                                              edit_area_fontsize,
-                                             arabic_pane_fontsize, bg_color,
+                                             arabic_area_fontsize, bg_color,
                                              font_color)
 
         # The server format is "name: url:port". We only need "name"

--- a/python/nammu/view/EditSettingsView.py
+++ b/python/nammu/view/EditSettingsView.py
@@ -246,6 +246,29 @@ class EditSettingsView(JDialog):
                                            fill=GridBagConstraints.HORIZONTAL)
         panel.add(self.edit_area_fs_field, constraints)
 
+    def build_arabic_pane_font_panel(self, constraints, panel):
+        '''
+        Font size in Arabic pane's textfield.
+        '''
+        fontzise_label = JLabel("Arabic pane font size:")
+        constraints = self.add_constraints(constraints, weightx=0.20,
+                                           gridx=0, gridy=1)
+        panel.add(fontzise_label, constraints)
+
+        self.arabic_pane_fs_field = JTextField()
+        self.arabic_pane_fs_field.setEditable(True)
+        if self.edit_area_fontsize:
+            self.arabic_pane_fs_field.setText(
+                "{}".format(self.edit_area_fontsize))
+        else:
+            self.arabic_pane_fs_field.setText(self.controller.config[
+                'arabic_pane_style']['fontsize']['default'])
+
+        constraints = self.add_constraints(constraints, weightx=0.80,
+                                           gridx=1, gridy=1,
+                                           fill=GridBagConstraints.HORIZONTAL)
+        panel.add(self.arabic_pane_fs_field, constraints)
+
     def build_combobox(self, choices, default):
         '''
         Generic method to construct a combobox. choices should be an iterable
@@ -328,6 +351,7 @@ class EditSettingsView(JDialog):
         self.build_console_font_color_panel(constraints, panel)
         self.build_console_background_color_panel(constraints, panel)
         self.build_edit_area_font_panel(constraints, panel)
+        self.build_arabic_pane_font_panel(constraints, panel)
         return panel
 
     def display(self):

--- a/resources/config/settings.yaml
+++ b/resources/config/settings.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.20
+version: 0.21
 
 languages:
     default: Sumerian

--- a/resources/config/settings.yaml
+++ b/resources/config/settings.yaml
@@ -124,4 +124,9 @@ edit_area_style:
         default: 14
         user: 14
 
+arabic_pane_style:
+    fontsize:
+        default: 14
+        user: 14
+
 new_user: True

--- a/resources/config/settings.yaml
+++ b/resources/config/settings.yaml
@@ -124,9 +124,9 @@ edit_area_style:
         default: 14
         user: 14
 
-arabic_pane_style:
+arabic_area_style:
     fontsize:
-        default: 14
-        user: 14
+        default: 16
+        user: 16
 
 new_user: True


### PR DESCRIPTION
This will automatically update the font of the related line numbers, too.  Fix #377. Fix #385.

Note: this is based on #376 and thus it should be merged after that PR.  The reason it's based on that PR is because they contain conflicting changes.  If you want to review this PR, just look at the last commit of the series.