### PR TITLE
Fix focus when undoing

### DIFF
--- a/python/nammu/controller/AtfAreaController.py
+++ b/python/nammu/controller/AtfAreaController.py
@@ -132,6 +132,8 @@ class AtfAreaController(object):
         ended.
         '''
         self.view.edit_listener.current_compound.end()
+        self.undo_manager.changeFocus("undo")
+
         try:
             self.undo_manager.undo()
         except CannotUndoException:
@@ -142,6 +144,7 @@ class AtfAreaController(object):
             self.syntax_highlight()
 
     def redo(self):
+        self.undo_manager.changeFocus("redo")
         try:
             self.undo_manager.redo()
         except CannotRedoException:

--- a/python/nammu/controller/AtfAreaController.py
+++ b/python/nammu/controller/AtfAreaController.py
@@ -140,7 +140,7 @@ class AtfAreaController(object):
                 self.undo_manager.undo()
         except (CannotUndoException, CannotRedoException):
             # These exceptions indicate we've reached the end of the edits
-            # vector.  Nothing to do
+            # vector. Nothing to do.
             pass
         else:
             if currentEdit:

--- a/python/nammu/controller/AtfAreaController.py
+++ b/python/nammu/controller/AtfAreaController.py
@@ -143,6 +143,12 @@ class AtfAreaController(object):
             # vector. Nothing to do.
             pass
         else:
+            # The following `if` is there only for the sake of safety, in case
+            # the previous `try` block leaks a falsy `currentEdit` which would
+            # cause an error when calling `firstEdit()` method.  If
+            # `currentEdit` is falsy it should raise one of the execptions
+            # caught above, so that only a truthy value should enter into this
+            # `else` branch.
             if currentEdit:
                 # Move focus to the pane where `currentEdit` was done.
                 editDoc = currentEdit.firstEdit().getDocument()

--- a/python/nammu/controller/AtfAreaController.py
+++ b/python/nammu/controller/AtfAreaController.py
@@ -123,6 +123,17 @@ class AtfAreaController(object):
         '''
         self.validation_errors = validation_errors
 
+    def moveFocus(self, currentEdit=None):
+        """
+        Move focus to the pane where `currentEdit` was done.
+        """
+        if currentEdit:
+            editDoc = currentEdit.firstEdit().getDocument()
+            if editDoc == self.arabic_area.getStyledDocument():
+                self.arabic_area.requestFocusInWindow()
+            elif editDoc == self.edit_area.getStyledDocument():
+                self.edit_area.requestFocusInWindow()
+
     def undo(self):
         '''
         CompoundEdits only get added  to the undo manager when the next
@@ -132,10 +143,10 @@ class AtfAreaController(object):
         ended.
         '''
         self.view.edit_listener.current_compound.end()
-        self.undo_manager.changeFocus("undo")
 
         try:
             self.undo_manager.undo()
+            self.moveFocus(self.undo_manager.editToBeUndone())
         except CannotUndoException:
             # This exception indicates we've reached the end of the edits
             # vector Nothing to do
@@ -144,9 +155,9 @@ class AtfAreaController(object):
             self.syntax_highlight()
 
     def redo(self):
-        self.undo_manager.changeFocus("redo")
         try:
             self.undo_manager.redo()
+            self.moveFocus(self.undo_manager.editToBeRedone())
         except CannotRedoException:
             # This exception indicates we've reached the end of the edits
             # vector - Nothing to do

--- a/python/nammu/controller/AtfAreaController.py
+++ b/python/nammu/controller/AtfAreaController.py
@@ -143,26 +143,37 @@ class AtfAreaController(object):
         ended.
         '''
         self.view.edit_listener.current_compound.end()
+        # Before actually undoing, get the edit about to be undone, in
+        # order to move focus to that pane
+        currentEdit = self.undo_manager.editToBeUndone()
+        if not currentEdit:
+            return
 
         try:
             self.undo_manager.undo()
-            self.moveFocus(self.undo_manager.editToBeUndone())
         except CannotUndoException:
-            # This exception indicates we've reached the end of the edits
-            # vector Nothing to do
+            # This exception should never be thrown because we're checking that
+            # there is something to undo.
             pass
         else:
+            self.moveFocus(currentEdit)
             self.syntax_highlight()
 
     def redo(self):
+        # Before actually redoing, get the edit about to be redone, in
+        # order to move focus to that pane
+        currentEdit = self.undo_manager.editToBeRedone()
+        if not currentEdit:
+            return
+
         try:
             self.undo_manager.redo()
-            self.moveFocus(self.undo_manager.editToBeRedone())
         except CannotRedoException:
-            # This exception indicates we've reached the end of the edits
-            # vector - Nothing to do
+            # This exception should never be thrown because we're checking that
+            # there is something to redo.
             pass
         else:
+            self.moveFocus(currentEdit)
             self.syntax_highlight()
 
     def __getattr__(self, name):

--- a/python/nammu/view/AtfAreaView.py
+++ b/python/nammu/view/AtfAreaView.py
@@ -19,7 +19,7 @@ along with Nammu.  If not, see <http://www.gnu.org/licenses/>.
 
 from java.awt import BorderLayout, Dimension, Point
 from java.awt.event import KeyListener, AdjustmentListener
-from java.awt.ComponentOrientation import RIGHT_TO_LEFT
+from java.awt.ComponentOrientation import RIGHT_TO_LEFT, LEFT_TO_RIGHT
 from javax.swing import JScrollPane, JPanel, JSplitPane, UIManager
 from javax.swing.text import StyleConstants
 from javax.swing.undo import UndoManager, CompoundEdit
@@ -61,7 +61,7 @@ class AtfAreaView(JPanel):
         self.arabic_line_numbers = self.controller.arabic_line_numbers
 
         # Set undo/redo manager to edit area
-        self.undo_manager = MyUndoManager(self)
+        self.undo_manager = AtfUndoManager(self)
         self.undo_manager.limit = 3000
         self.edit_listener = AtfUndoableEditListener(self)
         self.edit_area.getDocument().addUndoableEditListener(
@@ -405,7 +405,7 @@ class AtfUndoableEditListener(UndoableEditListener):
     def __init__(self, panel):
         self.panel = panel
         self.undo_manager = self.panel.undo_manager
-        self.current_compound = NewEdit()
+        self.current_compound = AtfCompoundEdit()
         self.must_compound = False
         self.deletion = UIManager.getString('AbstractDocument.deletionText')
         self.addition = UIManager.getString('AbstractDocument.additionText')
@@ -416,13 +416,13 @@ class AtfUndoableEditListener(UndoableEditListener):
         significant edit events that we want to put together in a compound
         edit.
         """
-        empty_compound = NewEdit()
+        empty_compound = AtfCompoundEdit()
         if not self.must_compound:
             self.must_compound = True
             if not self.current_compound.equals(empty_compound):
                 self.current_compound.end()
                 self.undo_manager.addEdit(self.current_compound)
-            self.current_compound = NewEdit()
+            self.current_compound = AtfCompoundEdit()
 
     def force_stop_compound(self):
         self.current_compound.end()
@@ -441,14 +441,14 @@ class AtfUndoableEditListener(UndoableEditListener):
             # to false. Note undo() only undoes compound edits when they
             # are not in progress.
             self.current_compound.end()
-            self.current_compound = NewEdit()
+            self.current_compound = AtfCompoundEdit()
             self.undo_manager.addEdit(self.current_compound)
 
         # Always add current edit to current compound
         self.current_compound.addEdit(edit)
 
 
-class NewEdit(CompoundEdit):
+class AtfCompoundEdit(CompoundEdit):
     # add a getter for a protected field
     def getEdits(self):
         field = CompoundEdit.getDeclaredField("edits")
@@ -459,7 +459,7 @@ class NewEdit(CompoundEdit):
         return self.getEdits()[0]
 
 
-class MyUndoManager(UndoManager):
+class AtfUndoManager(UndoManager):
     def __init__(self, panel):
         self.panel = panel
 

--- a/python/nammu/view/AtfAreaView.py
+++ b/python/nammu/view/AtfAreaView.py
@@ -449,18 +449,36 @@ class AtfUndoableEditListener(UndoableEditListener):
 
 
 class AtfCompoundEdit(CompoundEdit):
+    """
+    Compound edit for the ATF area, derived from `CompoundEdit`.
+
+    This exposes the protected field `edits` of the parent Java class.
+    """
     # add a getter for a protected field
     def getEdits(self):
+        """
+        Return the protected field 'edits' of the compound.
+        """
         field = CompoundEdit.getDeclaredField("edits")
         field.setAccessible(True)
         return field.get(self)
 
     def firstEdit(self):
+        """
+        Return the first edit in the compound.
+        """
         return self.getEdits()[0]
 
 
 class AtfUndoManager(UndoManager):
+    """
+    Undo manager of the ATF area, derived from `UndoManager`.
+
+    This exposes some protected methods of the parent Java class.
+    """
     def __init__(self, panel):
+        # This member is here only to ease debugging: you can access
+        # NammuController logger with `self.panel.controller.controller.logger`
         self.panel = panel
 
     def editToBeRedone(self):

--- a/python/nammu/view/AtfAreaView.py
+++ b/python/nammu/view/AtfAreaView.py
@@ -61,9 +61,9 @@ class AtfAreaView(JPanel):
         self.arabic_line_numbers = self.controller.arabic_line_numbers
 
         # Set undo/redo manager to edit area
-        self.undo_manager = UndoManager()
+        self.undo_manager = MyUndoManager(self)
         self.undo_manager.limit = 3000
-        self.edit_listener = AtfUndoableEditListener(self.undo_manager)
+        self.edit_listener = AtfUndoableEditListener(self)
         self.edit_area.getDocument().addUndoableEditListener(
                                                         self.edit_listener)
         self.arabic_area.getDocument().addUndoableEditListener(
@@ -402,9 +402,10 @@ class AtfUndoableEditListener(UndoableEditListener):
     TODO: Make compounds save whole words so undoing is not so much of a pain
           for the user.
     '''
-    def __init__(self, undo_manager):
-        self.undo_manager = undo_manager
-        self.current_compound = CompoundEdit()
+    def __init__(self, panel):
+        self.panel = panel
+        self.undo_manager = self.panel.undo_manager
+        self.current_compound = NewEdit()
         self.must_compound = False
         self.deletion = UIManager.getString('AbstractDocument.deletionText')
         self.addition = UIManager.getString('AbstractDocument.additionText')
@@ -415,13 +416,13 @@ class AtfUndoableEditListener(UndoableEditListener):
         significant edit events that we want to put together in a compound
         edit.
         """
-        empty_compound = CompoundEdit()
+        empty_compound = NewEdit()
         if not self.must_compound:
             self.must_compound = True
             if not self.current_compound.equals(empty_compound):
                 self.current_compound.end()
                 self.undo_manager.addEdit(self.current_compound)
-            self.current_compound = CompoundEdit()
+            self.current_compound = NewEdit()
 
     def force_stop_compound(self):
         self.current_compound.end()
@@ -440,8 +441,54 @@ class AtfUndoableEditListener(UndoableEditListener):
             # to false. Note undo() only undoes compound edits when they
             # are not in progress.
             self.current_compound.end()
-            self.current_compound = CompoundEdit()
+            self.current_compound = NewEdit()
             self.undo_manager.addEdit(self.current_compound)
 
         # Always add current edit to current compound
         self.current_compound.addEdit(edit)
+
+
+class NewEdit(CompoundEdit):
+    # add a getter for a protected field
+    def getEdits(self):
+        field = CompoundEdit.getDeclaredField("edits")
+        field.setAccessible(True)
+        return field.get(self)
+
+    def firstEdit(self):
+        return self.getEdits()[0]
+
+
+class MyUndoManager(UndoManager):
+    def __init__(self, panel):
+        self.panel = panel
+
+    def editToBeRedone(self):
+        """
+        Return the protected method `editToBeRedone()`.
+        """
+        return self.super__editToBeRedone()
+
+    def editToBeUndone(self):
+        """
+        Return the protected method `editToBeUndone()`.
+        """
+        return self.super__editToBeUndone()
+
+    def changeFocus(self, action=None):
+        """
+        Move focus to the pane where the current edit to redo/undo was done.
+        The `action` argument can be either `"undo"` or "`redo`".
+        """
+        currentEdit = None
+        if action == "undo":
+            currentEdit = self.editToBeUndone()
+        elif action == "redo":
+            currentEdit = self.editToBeRedone()
+
+        if currentEdit:
+            editDoc = currentEdit.firstEdit().getDocument()
+            if editDoc == self.panel.controller.arabic_area.getStyledDocument():
+                self.panel.controller.arabic_area.requestFocusInWindow()
+            elif editDoc == self.panel.controller.edit_area.getStyledDocument():
+                self.panel.controller.edit_area.requestFocusInWindow()

--- a/python/nammu/view/AtfAreaView.py
+++ b/python/nammu/view/AtfAreaView.py
@@ -474,21 +474,3 @@ class MyUndoManager(UndoManager):
         Return the protected method `editToBeUndone()`.
         """
         return self.super__editToBeUndone()
-
-    def changeFocus(self, action=None):
-        """
-        Move focus to the pane where the current edit to redo/undo was done.
-        The `action` argument can be either `"undo"` or "`redo`".
-        """
-        currentEdit = None
-        if action == "undo":
-            currentEdit = self.editToBeUndone()
-        elif action == "redo":
-            currentEdit = self.editToBeRedone()
-
-        if currentEdit:
-            editDoc = currentEdit.firstEdit().getDocument()
-            if editDoc == self.panel.controller.arabic_area.getStyledDocument():
-                self.panel.controller.arabic_area.requestFocusInWindow()
-            elif editDoc == self.panel.controller.edit_area.getStyledDocument():
-                self.panel.controller.edit_area.requestFocusInWindow()

--- a/python/nammu/view/AtfAreaView.py
+++ b/python/nammu/view/AtfAreaView.py
@@ -465,12 +465,12 @@ class AtfUndoManager(UndoManager):
 
     def editToBeRedone(self):
         """
-        Return the protected method `editToBeRedone()`.
+        Expose the protected method `editToBeRedone()`.
         """
         return self.super__editToBeRedone()
 
     def editToBeUndone(self):
         """
-        Return the protected method `editToBeUndone()`.
+        Expose the protected method `editToBeUndone()`.
         """
         return self.super__editToBeUndone()


### PR DESCRIPTION
This is my initial attempt at fixing #371.  There are two separate issues here:

1. focus stays in the current pane even if the edit being undone is in another pane
2. only when syntax highlighting is on, the caret moves to the second line of the edit area if this panel has focus and the edit to be undone is in the other pane

Currently this PR fixes the first issue, I marked it as draft because it's not yet complete, as I have to:
* [x] review the mechanism to request the focus in `AtfAreaController.undo()`, maybe it can be simplified
* [ ] fix the second issue
* [x] do the same for the redo