### PR TITLE
Compute limit of syntax highlighting with self.styledoc.getLengt…

### DIFF
--- a/python/nammu/controller/NammuController.py
+++ b/python/nammu/controller/NammuController.py
@@ -98,10 +98,6 @@ class NammuController(object):
         # TODO: save array with all opened ATFs
         self.currentFilename = None
 
-        # We need to initialise this so a conditional test in the syntax
-        # highlighter does not fail when we have no arabic translation
-        self.arabicIndex = None
-
         # Configure the tooltip manager for tooltips to appear quicker and not
         # to vanish until mouse moves away
         ToolTipManager.sharedInstance().setInitialDelay(0)
@@ -172,10 +168,10 @@ class NammuController(object):
                                             arabic=self.arabic_edition_on)
 
                 # Check for Arabic content and toggle arabic translation mode
-                self.arabicIndex = self.atfAreaController.findArabic(atfText)
-                if self.arabicIndex:
-                    self.atf_body = atfText[:self.arabicIndex]
-                    self.atf_translation = atfText[self.arabicIndex:]
+                arabicIndex = self.atfAreaController.findArabic(atfText)
+                if arabicIndex:
+                    self.atf_body = atfText[:arabicIndex]
+                    self.atf_translation = atfText[arabicIndex:]
                     self.arabic(force=True)
                 else:
                     # Turn off caret movement and highligting for file load

--- a/python/nammu/test/test_nammu.py
+++ b/python/nammu/test/test_nammu.py
@@ -199,6 +199,29 @@ class TestNammu(object):
         # An empty dictionary means no validation errors
         assert nammu.atfAreaController.validation_errors
 
+    def test_syntax_highlight_add_text(self, monkeypatch, nammu):
+        """
+        Test that syntax highlighting works correctly when adding lines to a
+        document with an Arabic translation.
+        """
+        monkeypatch.setattr(JFileChooser, 'showDialog',
+                            show_diag_patch)
+        monkeypatch.setattr(JFileChooser, 'getSelectedFile',
+                            selected_file_patch_arabic)
+        monkeypatch.setattr(nammu, 'handleUnsaved', unsaved_patch)
+        nammu.openFile()
+        edit_area = nammu.atfAreaController.edit_area
+        atf_body = edit_area.getText()
+        edit_area.setText(atf_body + '\n@obverse')
+
+        # Wait here so the highlight completes before getting the styledoc
+        time.sleep(2)
+        doc = edit_area.getStyledDocument()
+        caret = doc.getLength() - 2
+        # Get the colour of a given character that should be highlighted
+        c = doc.getForeground(doc.getCharacterElement(caret).getAttributes())
+        assert c.equals(blue())
+
     def test_file_load(self, monkeypatch, nammu):
         monkeypatch.setattr(JFileChooser, 'showDialog',
                             show_diag_patch)

--- a/python/nammu/view/SyntaxHighlighter.py
+++ b/python/nammu/view/SyntaxHighlighter.py
@@ -168,8 +168,8 @@ class SyntaxHighlighter:
 
         # when we have arabic text, we need to fix an off by 1 error caused
         # by how we split the panes
-        if self.controller.controller.arabicIndex:
-            no_of_chars = self.controller.controller.arabicIndex - 1
+        if self.controller.controller.arabic_edition_on:
+            no_of_chars = self.styledoc.getLength()
 
         # Get only the text on the screen
         # TODO: This exception can probably be understood and worked around

--- a/python/nammu/view/SyntaxHighlighter.py
+++ b/python/nammu/view/SyntaxHighlighter.py
@@ -166,8 +166,7 @@ class SyntaxHighlighter:
         if not self.syntax_highlight_on or no_of_chars < 1:
             return
 
-        # when we have arabic text, we need to fix an off by 1 error caused
-        # by how we split the panes
+        # When we have arabic text, use the length of the main edit area.
         if self.controller.controller.arabic_edition_on:
             no_of_chars = self.styledoc.getLength()
 


### PR DESCRIPTION
Fix #393.

As it is now, `NammuController.arabicIndex` is of little utility as it is only set when opening a new file and never again, thus I simply removed it.  In this PR I propose to use `self.styledoc.getLength()` to compute the upper limit of syntax highlighting when we have a file with an Arabic translation.