### PR TITLE
Add time.sleep to tests likely to fail

### DIFF
--- a/python/nammu/test/test_nammu.py
+++ b/python/nammu/test/test_nammu.py
@@ -207,6 +207,7 @@ class TestNammu(object):
         monkeypatch.setattr(nammu, 'handleUnsaved', unsaved_patch)
 
         nammu.openFile()
+        time.sleep(2)
         assert len(nammu.atfAreaController.edit_area.getText()) > 1
 
     def test_saving_split_pane(self, monkeypatch, tmpdir, arabic, nammu):
@@ -375,6 +376,7 @@ class TestNammu(object):
         edit_area.setText("Hello primary edit area!")
         arabic_area.setText("في شتة")
         nammu.atfAreaController.undo()
+        time.sleep(2)
         assert (edit_area.getText() == "Hello primary edit area!" and
                 arabic_area.getText() == "")
 
@@ -390,6 +392,7 @@ class TestNammu(object):
         arabic_area.setText("في شتة")
         nammu.atfAreaController.undo()
         nammu.atfAreaController.redo()
+        time.sleep(2)
         assert (edit_area.getText() == "Hello primary edit area!" and
                 arabic_area.getText() == "في شتة")
 
@@ -404,6 +407,7 @@ class TestNammu(object):
         arabic_area.setText("في شتة")
         edit_area.setText("Hello primary edit area!")
         nammu.atfAreaController.undo()
+        time.sleep(2)
         assert (edit_area.getText() == "" and
                 arabic_area.getText() == "في شتة")
 
@@ -419,6 +423,7 @@ class TestNammu(object):
         edit_area.setText("Hello primary edit area!")
         nammu.atfAreaController.undo()
         nammu.atfAreaController.redo()
+        time.sleep(2)
         assert (edit_area.getText() == "Hello primary edit area!" and
                 arabic_area.getText() == "في شتة")
 


### PR DESCRIPTION
This is a very ugly work-around (already used in other tests) rather than a real fix, but at least *drastically* reduces the rate of randomly failing tests for me: I had 2 failures out of 10 runs locally, compared to a close to 100% failure rate.