### PR TITLE
Work around issue in syntax highlighter

### DIFF
--- a/python/nammu/view/SyntaxHighlighter.py
+++ b/python/nammu/view/SyntaxHighlighter.py
@@ -208,9 +208,9 @@ class SyntaxHighlighter:
                                                  attribs,
                                                  True)
 
-    # Go through each token in the text, check which type it is to assign
-    # a colour to it, check which position it is to set up default or
-    # error background, etc.
+        # Go through each token in the text, check which type it is to assign
+        # a colour to it, check which position it is to set up default or
+        # error background, etc.
         for tok in self.lexer:
             if tok.type in self.tokencolorlu:
                 if type(self.tokencolorlu[tok.type]) is dict:
@@ -227,7 +227,21 @@ class SyntaxHighlighter:
                     color = self.tokencolorlu[tok.type][0]
                     styleline = self.tokencolorlu[tok.type][1]
                 if styleline:
-                    mylength = len(splittext[tok.lineno - 1])
+                    # `styleline` indicates whether we need to apply the style
+                    # to the whole line.
+                    if tok.lineno <= len(splittext):
+                        # Length of the full line.
+                        mylength = len(splittext[tok.lineno - 1])
+                    else:
+                        # For some reason, the line number stored in `tok` is
+                        # larger than the number of lines in `splittext`.  In
+                        # this case, ignore this token and issue a debug
+                        # message.  FIXME: this shouldn't happen.
+                        logger = self.controller.controller.logger
+                        logger.debug("Error in syntax_highlight: "
+                                     "trying to highlight a line after "
+                                     "the end of the file")
+                        continue
                 else:
                     mylength = len(tok.value)
                 if str(tok.lineno) in error_lines:


### PR DESCRIPTION
As explained in the comments I added, for some reason `tok.lineno` is larger than the number of elements of `splittext` (which is the vector containing the lines of the local variable `text`).

For example, it happens that `splittext` has value
```
[u'&P393071 = SAAB 17, 1', u'#p']
```
and `tok.lineno` has value `11`, so we were trying to access `splittext`, which has length 2, at element 10.  Note that `splittext` appears to be somehow "corrupted", while `self.lexer` has the full list of tokens of the same file.  I honestly don't understand why this happens.

The work around (it's not a real fix!) I'm proposing here is to check that `tok.lineno` is equal to or less than the length of `splittext` before trying to access the line, and if not then set `mylength` to 0 (which effectively doesn't highlight anything).  As an alternative, we might just `continue` if the check if false.

I'm mildly confident that the issue addressed by this PR happens only in tests because multiple files are quickly opened one after each other.  I never saw this issue while using Nammu.  In this sense, this is a more concrete way to address random failures in test than #397.