### PR TITLE
Install latest version of `requests` to fix security vulnerabili…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,8 @@
 
           <libraries>
             <param>--index-url=https://pypi.python.org/simple/</param>
-            <param>requests&lt;2.12.0</param>
+            <param>urllib3&lt;1.25</param>
+            <param>requests==2.22.0</param>
             <!--param>pytest&lt;3.0</param-->
 						<param>pyyaml</param>
 						<param>mako</param>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-requests<2.12.0
+urllib3<1.25
+requests==2.22.0
 pytest<3.0
 pyyaml
 mako


### PR DESCRIPTION
Version 2.20+ of `requests` is required for this.  `urllib3` is a dependency of `requests`, but versions 1.25+ only work with newer versions of `setuptools`.  We couldn’t install a newer version of `setuptools`, so we fixed `urllib3` to the latest installable version (1.24.3).

Fixes #351.