### PR TITLE
Pin version of MarkupSafe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ before_install:
 install:
   - |
     if ! [ -z "$PYTEST" ]; then
+       # Install MarkupSafe separately to make sure the version we want is
+       # picked up
+       pip install --user MarkupSafe==1.1.1
        pip install --user -r requirements.txt
        mkdir $HOME/build/$TRAVIS_REPO_SLUG/resources/lib
        javac -d $HOME/build/$TRAVIS_REPO_SLUG/resources/lib $HOME/build/$TRAVIS_REPO_SLUG/src/main/java/uk/ac/ucl/rc/development/oracc/ext/*.java

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,7 @@
             <param>requests==2.22.0</param>
             <!--param>pytest&lt;3.0</param-->
             <param>pyyaml==5.2</param>
+            <param>MarkupSafe==1.1.1</param>
 						<param>mako</param>
 						<param>ply</param>
 						<param>jython-swingutils</param>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ urllib3<1.25
 requests==2.22.0
 pytest<3.0
 pyyaml==5.2
+MarkupSafe==1.1.1
 mako
 ply
 jython-swingutils


### PR DESCRIPTION
We need to add `MarkupSafe` to the list of dependencies because it's required by
mako and we want to pin it to version 1.x, since version 2 has dropped support
for Python 2.